### PR TITLE
🔬🧪🧬 [Refactor] Divide enum objects and data model objects into 2 different modules.

### DIFF
--- a/smoothcrawler_cluster/model/__init__.py
+++ b/smoothcrawler_cluster/model/__init__.py
@@ -1,1 +1,2 @@
-from .metadata import CrawlerStateRole, TaskResult, State, Task, Heartbeat
+from .metadata import State, Task, Heartbeat
+from .metadata_enum import CrawlerStateRole, TaskResult

--- a/smoothcrawler_cluster/model/metadata.py
+++ b/smoothcrawler_cluster/model/metadata.py
@@ -1,69 +1,7 @@
-from datetime import datetime as dt
 from typing import List, Union
-from enum import Enum
+from datetime import datetime as dt
 
-
-
-class CrawlerStateRole(Enum):
-    """
-    This role is NOT the role of *SmoothCrawler-AppIntegration*. They're very different. The role in
-    *SmoothCrawler-AppIntegration* means source site (or producer) of application or processor site
-    (or consumer) of application. But the role in meta-data in *SmoothCrawler-Cluster* means it is
-    active runner to run task or backup of that active runner.
-
-    For **SmoothCrawler-Cluster** realm, it has 4 different roles:
-
-    * Runner
-    * Backup Runner
-    * Dead Runner
-    * Dead Backup Runner
-    """
-
-    Runner = "runner"
-    """ Literally, **Runner** role is the major element to run web spider tasks. """
-
-    Backup_Runner = "backup-runner"
-    """
-    **Backup Runner** role is the backup of **Runner**. It would activate (base on the setting, it may 
-    activate immediately) and run the web spider task if it still not finish. 
-    A **Backup Runner** would keep checking the heartbeat info of **Runner**, standby and ready to run 
-    in anytime for any one of **Runner** does not keep updating its own heartbeat info (and it would turn 
-    to **Dead Runner** at that time).
-    """
-
-    Dead_Runner = "dead-runner"
-    """ 
-    If **Runner** cannot work finely, like the entire VM be shutdown where the crawler runtime environment 
-    in. It would turn to be **Dead Runner** from **Runner**. In other words, it must to be **Dead Runner** 
-    if it cannot keep updating its own heartbeat info.
-    """
-
-    Dead_Backup_Runner = "dead-backup-runner"
-    """ **Dead Backup Runner** is same as **Dead Runner** but it's for **Backup Runner**. """
-
-
-
-class TaskResult(Enum):
-    """
-    The task result means it is the result of running web spider task. The web spider task could classify to
-    be 4 different states: processing, done, terminate and error.
-    """
-
-    Processing = "processing"
-    """ Task running in processing. """
-
-    Done = "done"
-    """ Finish the task and it works finely without any exceptions. """
-
-    Terminate = "terminate"
-    """ 
-    Web spider task running has been terminated so that it cannot finish all processes, but it doesn't occur 
-    any exceptions except KeyboardInterrupt.
-    """
-
-    Error = "error"
-    """ If it raise any exceptions in web spider task running, its result would be error. """
-
+from .metadata_enum import CrawlerStateRole, TaskResult
 
 
 class State:

--- a/smoothcrawler_cluster/model/metadata_enum.py
+++ b/smoothcrawler_cluster/model/metadata_enum.py
@@ -1,0 +1,61 @@
+from enum import Enum
+
+
+class CrawlerStateRole(Enum):
+    """
+    This role is NOT the role of *SmoothCrawler-AppIntegration*. They're very different. The role in
+    *SmoothCrawler-AppIntegration* means source site (or producer) of application or processor site
+    (or consumer) of application. But the role in meta-data in *SmoothCrawler-Cluster* means it is
+    active runner to run task or backup of that active runner.
+
+    For **SmoothCrawler-Cluster** realm, it has 4 different roles:
+
+    * Runner
+    * Backup Runner
+    * Dead Runner
+    * Dead Backup Runner
+    """
+
+    Runner = "runner"
+    """ Literally, **Runner** role is the major element to run web spider tasks. """
+
+    Backup_Runner = "backup-runner"
+    """
+    **Backup Runner** role is the backup of **Runner**. It would activate (base on the setting, it may 
+    activate immediately) and run the web spider task if it still not finish. 
+    A **Backup Runner** would keep checking the heartbeat info of **Runner**, standby and ready to run 
+    in anytime for any one of **Runner** does not keep updating its own heartbeat info (and it would turn 
+    to **Dead Runner** at that time).
+    """
+
+    Dead_Runner = "dead-runner"
+    """ 
+    If **Runner** cannot work finely, like the entire VM be shutdown where the crawler runtime environment 
+    in. It would turn to be **Dead Runner** from **Runner**. In other words, it must to be **Dead Runner** 
+    if it cannot keep updating its own heartbeat info.
+    """
+
+    Dead_Backup_Runner = "dead-backup-runner"
+    """ **Dead Backup Runner** is same as **Dead Runner** but it's for **Backup Runner**. """
+
+
+class TaskResult(Enum):
+    """
+    The task result means it is the result of running web spider task. The web spider task could classify to
+    be 4 different states: processing, done, terminate and error.
+    """
+
+    Processing = "processing"
+    """ Task running in processing. """
+
+    Done = "done"
+    """ Finish the task and it works finely without any exceptions. """
+
+    Terminate = "terminate"
+    """ 
+    Web spider task running has been terminated so that it cannot finish all processes, but it doesn't occur 
+    any exceptions except KeyboardInterrupt.
+    """
+
+    Error = "error"
+    """ If it raise any exceptions in web spider task running, its result would be error. """

--- a/test/unit_test/model/metadata.py
+++ b/test/unit_test/model/metadata.py
@@ -1,77 +1,11 @@
-from smoothcrawler_cluster.model.metadata import CrawlerStateRole, TaskResult, State, Task, Heartbeat
+from smoothcrawler_cluster.model.metadata import State, Task, Heartbeat
+from smoothcrawler_cluster.model import CrawlerStateRole, TaskResult
 
-from typing import List, Dict, Callable, TypeVar
-from enum import Enum
+from typing import List, Dict, Callable
 from abc import ABCMeta
 import traceback
 import pytest
 import random
-
-
-_EnumT = TypeVar("_EnumT", bound=Enum)
-
-
-class _EnumObjTest(metaclass=ABCMeta):
-
-    def _run_enum_value_test(self, under_test_enum: Enum, expected_value: str) -> None:
-        assert under_test_enum.value == expected_value, f"The value of enum member '{under_test_enum}' should be '{expected_value}'."
-
-
-
-class TestCrawlerStateRole(_EnumObjTest):
-    """Test for the enum object key-value mapping."""
-
-    def test_runner_value(self) -> None:
-        _under_test_enum = CrawlerStateRole.Runner
-        _expected_value = "runner"
-        self._run_enum_value_test(_under_test_enum, _expected_value)
-
-
-    def test_backup_runner_value(self) -> None:
-        _under_test_enum = CrawlerStateRole.Backup_Runner
-        _expected_value = "backup-runner"
-        self._run_enum_value_test(_under_test_enum, _expected_value)
-
-
-    def test_dead_runner_value(self) -> None:
-        _under_test_enum = CrawlerStateRole.Dead_Runner
-        _expected_value = "dead-runner"
-        self._run_enum_value_test(_under_test_enum, _expected_value)
-
-
-    def test_dead_backup_runner_value(self) -> None:
-        _under_test_enum = CrawlerStateRole.Dead_Backup_Runner
-        _expected_value = "dead-backup-runner"
-        self._run_enum_value_test(_under_test_enum, _expected_value)
-
-
-
-class TestTaskResult(_EnumObjTest):
-    """Test for the enum object key-value mapping."""
-
-    def test_processing_value(self) -> None:
-        _under_test_enum = TaskResult.Processing
-        _expected_value = "processing"
-        self._run_enum_value_test(_under_test_enum, _expected_value)
-
-
-    def test_done_value(self) -> None:
-        _under_test_enum = TaskResult.Done
-        _expected_value = "done"
-        self._run_enum_value_test(_under_test_enum, _expected_value)
-
-
-    def test_terminate_value(self) -> None:
-        _under_test_enum = TaskResult.Terminate
-        _expected_value = "terminate"
-        self._run_enum_value_test(_under_test_enum, _expected_value)
-
-
-    def test_error_value(self) -> None:
-        _under_test_enum = TaskResult.Error
-        _expected_value = "error"
-        self._run_enum_value_test(_under_test_enum, _expected_value)
-
 
 
 class _MetaDataTest(metaclass=ABCMeta):
@@ -134,14 +68,12 @@ class _MetaDataTest(metaclass=ABCMeta):
             assert False, f"It should work finely without any issue.\n The error is: {traceback.format_exc()}"
 
 
-
 class TestState(_MetaDataTest):
     """Test for all the attributes of **State**."""
 
     @pytest.fixture(scope="function")
     def state(self) -> State:
         return State()
-
 
     def test_set_role_correctly(self, state: State) -> None:
         """
@@ -173,7 +105,6 @@ class TestState(_MetaDataTest):
             assert True, "It works finely."
             assert state.role == "runner", "The value should be same as it set."
 
-
     def test_set_role_incorrectly(self, state: State) -> None:
         """
         Test for setting the property *role* with invalid string value.
@@ -190,7 +121,6 @@ class TestState(_MetaDataTest):
             assert state.role is None, "The value should be None because it got fail when it set the value."
         else:
             assert False, f"It should work finely without any issue.\n The error is: {traceback.format_exc()}"
-
 
     def test_total_crawler(self, state: State) -> None:
         """
@@ -214,7 +144,6 @@ class TestState(_MetaDataTest):
             invalid_2_value=5.5
         )
 
-
     def test_total_runner(self, state: State) -> None:
         """
         Test for the property *total_runner* of **State**.
@@ -236,7 +165,6 @@ class TestState(_MetaDataTest):
             invalid_1_value="5",
             invalid_2_value=5.5
         )
-
 
     def test_total_backup(self, state: State) -> None:
         """
@@ -260,7 +188,6 @@ class TestState(_MetaDataTest):
             invalid_2_value=5.5
         )
 
-
     def test_current_crawler(self, state: State) -> None:
         """
         Test for the property *current_crawler* of **State**.
@@ -282,7 +209,6 @@ class TestState(_MetaDataTest):
             invalid_1_value="5",
             invalid_2_value={"k1": "v1", "k2": "v2", "k3": "v3"}
         )
-
 
     def test_current_runner(self, state: State) -> None:
         """
@@ -306,7 +232,6 @@ class TestState(_MetaDataTest):
             invalid_2_value={"k1": "v1", "k2": "v2", "k3": "v3"}
         )
 
-
     def test_current_backup(self, state: State) -> None:
         """
         Test for the property *current_backup* of **State**.
@@ -328,7 +253,6 @@ class TestState(_MetaDataTest):
             invalid_1_value="5",
             invalid_2_value={"k1": "v1", "k2": "v2", "k3": "v3"}
         )
-
 
     def test_standby_id(self, state: State) -> None:
         """
@@ -352,7 +276,6 @@ class TestState(_MetaDataTest):
             invalid_2_value=["iron_man_1"]
         )
 
-
     def test_fail_crawler(self, state: State) -> None:
         """
         Test for the property *fail_crawler* of **State**.
@@ -375,7 +298,6 @@ class TestState(_MetaDataTest):
             invalid_2_value={"k1": "v1", "k2": "v2", "k3": "v3"}
         )
 
-
     def test_fail_runner(self, state: State) -> None:
         """
         Test for the property *fail_runner* of **State**.
@@ -397,7 +319,6 @@ class TestState(_MetaDataTest):
             invalid_1_value="5",
             invalid_2_value={"k1": "v1", "k2": "v2", "k3": "v3"}
         )
-
 
     def test_fail_backup(self, state: State) -> None:
         """
@@ -422,14 +343,12 @@ class TestState(_MetaDataTest):
         )
 
 
-
 class TestTask(_MetaDataTest):
     """Test for all the attributes of **Task**."""
 
     @pytest.fixture(scope="function")
     def task(self) -> Task:
         return Task()
-
 
     def test_task_content(self, task: Task) -> None:
 
@@ -446,7 +365,6 @@ class TestTask(_MetaDataTest):
             invalid_1_value="5",
             invalid_2_value=["spider_1"]
         )
-
 
     def test_task_result(self, task: Task) -> None:
 
@@ -465,14 +383,12 @@ class TestTask(_MetaDataTest):
         )
 
 
-
 class TestHeartbeat(_MetaDataTest):
     """Test for all the attributes of **Heartbeat**."""
 
     @pytest.fixture(scope="function")
     def heartbeat(self) -> Heartbeat:
         return Heartbeat()
-
 
     def test_datetime(self, heartbeat: Heartbeat) -> None:
 

--- a/test/unit_test/model/metadata_enum.py
+++ b/test/unit_test/model/metadata_enum.py
@@ -1,0 +1,58 @@
+from smoothcrawler_cluster.model import CrawlerStateRole, TaskResult
+from enum import Enum
+from abc import ABCMeta
+
+
+class _EnumObjTest(metaclass=ABCMeta):
+
+    @classmethod
+    def _run_enum_value_test(cls, under_test_enum: Enum, expected_value: str) -> None:
+        assert under_test_enum.value == expected_value, f"The value of enum member '{under_test_enum}' should be '{expected_value}'."
+
+
+class TestCrawlerStateRole(_EnumObjTest):
+    """Test for the enum object key-value mapping."""
+
+    def test_runner_value(self) -> None:
+        _under_test_enum = CrawlerStateRole.Runner
+        _expected_value = "runner"
+        self._run_enum_value_test(_under_test_enum, _expected_value)
+
+    def test_backup_runner_value(self) -> None:
+        _under_test_enum = CrawlerStateRole.Backup_Runner
+        _expected_value = "backup-runner"
+        self._run_enum_value_test(_under_test_enum, _expected_value)
+
+    def test_dead_runner_value(self) -> None:
+        _under_test_enum = CrawlerStateRole.Dead_Runner
+        _expected_value = "dead-runner"
+        self._run_enum_value_test(_under_test_enum, _expected_value)
+
+    def test_dead_backup_runner_value(self) -> None:
+        _under_test_enum = CrawlerStateRole.Dead_Backup_Runner
+        _expected_value = "dead-backup-runner"
+        self._run_enum_value_test(_under_test_enum, _expected_value)
+
+
+class TestTaskResult(_EnumObjTest):
+    """Test for the enum object key-value mapping."""
+
+    def test_processing_value(self) -> None:
+        _under_test_enum = TaskResult.Processing
+        _expected_value = "processing"
+        self._run_enum_value_test(_under_test_enum, _expected_value)
+
+    def test_done_value(self) -> None:
+        _under_test_enum = TaskResult.Done
+        _expected_value = "done"
+        self._run_enum_value_test(_under_test_enum, _expected_value)
+
+    def test_terminate_value(self) -> None:
+        _under_test_enum = TaskResult.Terminate
+        _expected_value = "terminate"
+        self._run_enum_value_test(_under_test_enum, _expected_value)
+
+    def test_error_value(self) -> None:
+        _under_test_enum = TaskResult.Error
+        _expected_value = "error"
+        self._run_enum_value_test(_under_test_enum, _expected_value)


### PR DESCRIPTION
### _Target_

* Divide enum objects and data model objects into 2 different modules.
    * Enum objects -> _smoothcrawler_cluster.model.metadata_enum_
    * Data model objects -> _smoothcrawler_cluster.model.metadata_


### _Modify Code Scope_

* Source code:
    * Sub-package _smoothcrawler_cluster.model_.
        * Modified: _smoothcrawler_cluster.model.metadata_
        * New filed: _smoothcrawler_cluster.model.metadata_enum_

* Testing code:
    * Testing module test.unit_test.model.metadata.
        * Modified: test/unit_test/model/metadata.py
        * New filed: test/unit_test/model/metadata_enum.py


### _Effecting Scope_

* All usage about operations of meta data in client site may need to modify the importing path like below:

Previous:
```python
from .metadata import CrawlerStateRole, TaskResult, State, Task, Heartbeat
```

New:
```python
from .metadata import State, Task, Heartbeat
from .metadata_enum import CrawlerStateRole, TaskResult
```


### _Description_

* Move all enum objects code to another module **_metadata_enum_** to let point of code to be more clear.
