### PR TITLE
🎉🎊🍾 [New Feature] (code + test) Finish 3 new features register, is_ready and elect of module crawler

### DIFF
--- a/smoothcrawler_cluster/_utils/zookeeper.py
+++ b/smoothcrawler_cluster/_utils/zookeeper.py
@@ -203,26 +203,12 @@ class ZookeeperClient(_BaseZookeeperClient):
             return self.exist_node(path)
 
     def get_node(self, path: str) -> Generic[_BaseZookeeperNodeType]:
+        _data, _state = self.__zk_client.get(path=path)
 
-        def _get_value() -> (bytes, ZnodeStat):
-            __data = None
-            __state = None
-
-            @self.__zk_client.DataWatch(path)
-            def _get_value_from_path(data: bytes, state: ZnodeStat):
-                nonlocal __data, __state
-                __data = data
-                __state = state
-
-            return __data, __state
-
-        _data, _state = _get_value()
         _zk_path = ZookeeperNode()
         _zk_path.path = path
-        if _data is not None and type(_data) is bytes:
-            _zk_path.value = _data.decode("utf-8")
-        else:
-            _zk_path.value = _data
+        _zk_path.value = _data.decode("utf-8")
+
         return _zk_path
 
     def restrict_get_node(self, path: str, restrict: ZookeeperRecipe, identifier: str, max_leases: int = None) -> Generic[_BaseZookeeperNodeType]:

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -183,7 +183,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
         state.total_crawler = self._runner + self._backup
         state.total_runner = self._runner
         state.total_backup = self._backup
-        state.current_crawler = state.current_crawler.append(self._crawler_name)
+        state.current_crawler.append(self._crawler_name)
         state.role = CrawlerStateRole.Initial
         state.standby_id = "0"
         return state
@@ -191,10 +191,12 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
     def _update_crawler_role(self, role: CrawlerStateRole) -> None:
         _state = self._get_state_from_zookeeper()
         _state.role = role
+        _state.current_crawler.append(self._crawler_name)
         if role is CrawlerStateRole.Runner:
-            _state.current_runner = _state.current_runner.append(self._crawler_name)
+            _state.current_runner.append(self._crawler_name)
         elif role is CrawlerStateRole.Backup_Runner:
-            _state.current_backup = _state.current_backup.append(self._crawler_name)
+            _state.current_backup.append(self._crawler_name)
+        self._set_state_to_zookeeper(_state, create_node=False)
 
     def _initial_task(self) -> Task:
         _task = Task()

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -90,7 +90,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
         # Current Answer:
         # 1. Index: get data from Zookeeper first and check the value, and it set the next index of crawler and save it to Zookeeper.
         # 2. Hardware code: Use the unique hardware code or flag to record it, i.e., the MAC address of host or something ID of container.
-        if self._Zookeeper_Client.exist_node(path=self.state_zookeeper_path) is False:
+        if self._Zookeeper_Client.exist_node(path=self.state_zookeeper_path) is None:
             _state = self._initial_state()
             self._set_state_to_zookeeper(_state, create_node=True)
         else:
@@ -99,7 +99,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
             self._set_state_to_zookeeper(_state)
 
         # Register attribute of Task
-        if self._Zookeeper_Client.exist_node(path=self.task_zookeeper_path) is False:
+        if self._Zookeeper_Client.exist_node(path=self.task_zookeeper_path) is None:
             _task = self._initial_task()
             self._set_task_to_zookeeper(_task, create_node=True)
         else:
@@ -108,7 +108,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
             self._set_task_to_zookeeper(_task)
 
         # Register attribute of Heartbeat
-        if self._Zookeeper_Client.exist_node(path=self.heartbeat_zookeeper_path) is False:
+        if self._Zookeeper_Client.exist_node(path=self.heartbeat_zookeeper_path) is None:
             _heartbeat = self._initial_heartbeat()
             self._set_heartbeat_to_zookeeper(_heartbeat, create_node=True)
         else:

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -231,7 +231,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
         _start = time.time()
         while True:
             _state = self._get_state_from_zookeeper()
-            if len(_state.current_crawler) == self._total_crawler:
+            if len(set(_state.current_crawler)) == self._total_crawler:
                 return True
             if timeout != -1:
                 if (time.time() - _start) >= timeout:

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -1,9 +1,16 @@
-from typing import Type
+from datetime import datetime
+from typing import List, Type, TypeVar, Generic
 from abc import ABCMeta
+import time
 
+from .model.metadata_enum import CrawlerStateRole, TaskResult
 from .model.metadata import State, Task, Heartbeat
+from .election import BaseElection, IndexElection, ElectionResult
 from ._utils.converter import BaseConverter, JsonStrConverter
 from ._utils.zookeeper import ZookeeperClient
+
+
+BaseElectionType = TypeVar("BaseElectionType", bound=BaseElection)
 
 
 class BaseDistributedCrawler(metaclass=ABCMeta):
@@ -19,13 +26,18 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
     _Zookeeper_Client: ZookeeperClient = None
     __Default_Zookeeper_Hosts: str = "localhost:2181"
 
-    def __init__(self, runner: int, backup: int, name: str = "", zk_hosts: str = None, zk_converter: Type[BaseConverter] = None):
+    def __init__(self, runner: int, backup: int, name: str = "", index_sep: List[str] = ["-", "_"], zk_hosts: str = None,
+                 zk_converter: Type[BaseConverter] = None, election_strategy: Generic[BaseElectionType] = None):
         super().__init__()
+        self._total_crawler = runner + backup
         self._runner = runner
         self._backup = backup
+        self._crawler_role: CrawlerStateRole = None
+        self._index_sep = ""
 
         if name == "":
-            name = "crawler"
+            name = "sc-crawler_1"
+            self._index_sep = "_"
         self._crawler_name = name
 
         if zk_hosts is None:
@@ -35,6 +47,35 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
         if zk_converter is None:
             zk_converter = JsonStrConverter()
         self._zk_converter = zk_converter
+
+        if election_strategy is None:
+            election_strategy = IndexElection()
+        self._election_strategy = election_strategy
+        if self._index_sep == "":
+            for _sep in index_sep:
+                _crawler_name_list = self._crawler_name.split(sep=_sep)
+                if len(_crawler_name_list) > 1:
+                    self._index_sep = _sep
+                    self._crawler_index = _crawler_name_list[-1]
+                    self._election_strategy.identity = self._crawler_index
+                    break
+        else:
+            _crawler_name_list = self._crawler_name.split(sep=self._index_sep)
+            self._crawler_index = _crawler_name_list[-1]
+            self._election_strategy.identity = self._crawler_index
+
+        # TODO: It needs create another thread to keep updating heartbeat info to signal it's alive.
+        self.register()
+        if self.is_ready(interval=0.5, timeout=-1):
+            if self.elect() is ElectionResult.Winner:
+                self._crawler_role = CrawlerStateRole.Runner
+            else:
+                self._crawler_role = CrawlerStateRole.Backup_Runner
+            self._update_crawler_role(self._crawler_role)
+
+    @property
+    def role(self) -> CrawlerStateRole:
+        return self._crawler_role
 
     @property
     def zookeeper_hosts(self) -> str:
@@ -55,7 +96,22 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
             self._set_state_to_zookeeper(_state)
 
         # Register attribute of Task
+        if self._Zookeeper_Client.exist_node(path=self.task_zookeeper_path) is False:
+            _task = self._initial_task()
+            self._set_task_to_zookeeper(_task, create_node=True)
+        else:
+            _task = self._get_task_from_zookeeper()
+            _task = self._update_task(task=_task)
+            self._set_task_to_zookeeper(_task)
+
         # Register attribute of Heartbeat
+        if self._Zookeeper_Client.exist_node(path=self.heartbeat_zookeeper_path) is False:
+            _heartbeat = self._initial_heartbeat()
+            self._set_heartbeat_to_zookeeper(_heartbeat, create_node=True)
+        else:
+            _heartbeat = self._get_heartbeat_from_zookeeper()
+            _heartbeat = self._update_heartbeat(heartbeat=_heartbeat)
+            self._set_heartbeat_to_zookeeper(_heartbeat)
 
     @property
     def state_zookeeper_path(self) -> str:
@@ -107,51 +163,86 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
 
     def _initial_state(self) -> State:
         _state = State()
+        _state.total_crawler = self._runner + self._backup
         _state.total_runner = self._runner
         _state.total_backup = self._backup
-        _state.total_crawler = self._runner + self._backup
+        _state.role = CrawlerStateRole.Initial
+        _state.current_crawler = [self._crawler_name]
+        _state.current_runner = []
+        _state.current_backup = []
+        _state.standby_id = "0"
+        _state.fail_crawler = []
+        _state.fail_runner = []
+        _state.fail_backup = []
         return _state
 
     def _update_state(self, state: State) -> State:
+        state.total_crawler = self._runner + self._backup
         state.total_runner = self._runner
         state.total_backup = self._backup
-        state.total_crawler = self._runner + self._backup
+        state.current_crawler = state.current_crawler.append(self._crawler_name)
+        state.role = CrawlerStateRole.Initial
+        state.standby_id = "0"
         return state
+
+    def _update_crawler_role(self, role: CrawlerStateRole) -> None:
+        _state = self._get_state_from_zookeeper()
+        _state.role = role
+        if role is CrawlerStateRole.Runner:
+            _state.current_runner = _state.current_runner.append(self._crawler_name)
+        elif role is CrawlerStateRole.Backup_Runner:
+            _state.current_backup = _state.current_backup.append(self._crawler_name)
 
     def _initial_task(self) -> Task:
         _task = Task()
         # TODO: Consider about the task assigning timing
-        _task.task_result = None
+        _task.task_result = TaskResult.Nothing
         _task.task_content = None
         return _task
 
     def _update_task(self, task: Task) -> Task:
         # TODO: Consider about the task assigning timing
-        task.task_result = None
+        task.task_result = TaskResult.Nothing
         task.task_content = None
         return task
 
     def _initial_heartbeat(self) -> Heartbeat:
         _heartbeat = Heartbeat()
         # TODO: How to assign heartbeat value?
-        import datetime
-        _heartbeat.datetime = datetime.datetime.now()
+        _heartbeat.datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         return _heartbeat
 
     def _update_heartbeat(self, heartbeat: Heartbeat) -> Heartbeat:
         # TODO: How to assign heartbeat value?
-        import datetime
-        heartbeat.datetime = datetime.datetime.now()
+        heartbeat.datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         return heartbeat
 
-    def is_ready(self):
-        pass
+    def is_ready(self, interval: float = 0.5, timeout: float = -1) -> bool:
+        if timeout < -1:
+            raise ValueError("The option *timeout* value is incorrect. Please configure more than -1, and -1 means it never timeout.")
 
-    def elect(self):
-        pass
+        _start = time.time()
+        while True:
+            _state = self._get_state_from_zookeeper()
+            if _state.total_crawler == self._total_crawler:
+                return True
+            if timeout != -1:
+                if (time.time() - _start) >= timeout:
+                    return False
+            time.sleep(interval)
+
+    def elect(self) -> ElectionResult:
+        _state = self._get_state_from_zookeeper()
+        return self._election_strategy.elect(candidate=self._crawler_name, member=_state.current_crawler, index_sep=self._index_sep, spot=self._runner)
 
     def run(self):
-        pass
+        if self._crawler_role is CrawlerStateRole.Runner:
+            self.wait_for_task()
+            self.run_task()
+        elif self._crawler_role is CrawlerStateRole.Backup_Runner:
+            self.wait_and_standby()
+            self.discover()
+            self.activate()
 
     def wait_for_task(self):
         pass

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -231,7 +231,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
         _start = time.time()
         while True:
             _state = self._get_state_from_zookeeper()
-            if _state.total_crawler == self._total_crawler:
+            if len(_state.current_crawler) == self._total_crawler:
                 return True
             if timeout != -1:
                 if (time.time() - _start) >= timeout:

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -183,6 +183,8 @@ class ZookeeperCrawler(BaseDecentralizedCrawler):
         state.total_crawler = self._runner + self._backup
         state.total_runner = self._runner
         state.total_backup = self._backup
+        if state.current_crawler is None:
+            state.current_crawler = []
         state.current_crawler.append(self._crawler_name)
         state.role = CrawlerStateRole.Initial
         state.standby_id = "0"

--- a/smoothcrawler_cluster/election.py
+++ b/smoothcrawler_cluster/election.py
@@ -30,7 +30,8 @@ class IndexElection(BaseElection):
 
     def elect(self, candidate: str, member: List[str], index_sep: str, spot: int) -> ElectionResult:
         _member_indexs = map(lambda one_member: int(one_member.split(sep=index_sep)[-1]), member)
-        _winner = sorted(list(_member_indexs))[0:spot]
+        _sorted_list = sorted(list(_member_indexs))
+        _winner = _sorted_list[0:spot]
         _is_winner = list(map(lambda winner_index: str(winner_index) in candidate, _winner))
         if True in _is_winner:
             return ElectionResult.Winner

--- a/test/_assertion.py
+++ b/test/_assertion.py
@@ -1,0 +1,42 @@
+from typing import Any, AnyStr
+from enum import Enum
+import re
+
+
+class WorkingTime(Enum):
+    AtInitial = "In initialing process"
+    AfterUpdateInInitial = "After updating in initial process"
+
+
+def ValueFormatAssertion(target: str, regex: re.Pattern[AnyStr]):
+    assert target is not None, "The path value should not be None."
+
+    _search_char_result = re.search(regex, str(target))
+    assert _search_char_result is not None, f"Its format is not correct. It should be like '{regex}'."
+
+
+def ObjectIsNoneOrNotAssertion(working_time: WorkingTime, uit_obj: Any, is_none: bool = False):
+    if is_none is True:
+        assert uit_obj is None, f"{working_time.value}, object *{uit_obj.__class__.__name__}* should be None."
+    else:
+        assert uit_obj is not None, f"{working_time.value}, object *{uit_obj.__class__.__name__}* should NOT be None."
+
+
+def ValueAssertion(working_time: WorkingTime, uit_obj: Any, metadata: str, expected_value: Any = None, is_none: bool = False) -> str:
+    if expected_value is None:
+        if is_none is True:
+            _assertion = f"{working_time.value}, meta data *{uit_obj.__class__.__name__}.{metadata}* should be None."
+            assert getattr(uit_obj, metadata) is None, _assertion
+        else:
+            _assertion = f"{working_time.value}, meta data *{uit_obj.__class__.__name__}.{metadata}* should not be None."
+            assert getattr(uit_obj, metadata) is not None, _assertion
+    else:
+        _metadata_value = getattr(uit_obj, metadata)
+        _assertion = f"{working_time.value}, meta data *{uit_obj.__class__.__name__}.{metadata}* should be {expected_value}, but it got {_metadata_value}."
+        assert _metadata_value == expected_value, _assertion
+
+
+def ListSizeAssertion(working_time: WorkingTime, uit_obj: Any, metadata: str, expected_value: int):
+    _metadata_value = getattr(uit_obj, metadata)
+    assert len(_metadata_value) == expected_value, f"{working_time.value}, meta data *{uit_obj.__class__.__name__}.{metadata}* list size should be " \
+                                                   f"{expected_value}, but it got {len(_metadata_value)} (list detail: {_metadata_value})."

--- a/test/integration_test/_utils/zookeeper.py
+++ b/test/integration_test/_utils/zookeeper.py
@@ -5,7 +5,7 @@ from smoothcrawler_cluster._utils.zookeeper import (
     _BaseZookeeperListener
 )
 from kazoo.client import KazooClient
-from kazoo.exceptions import NodeExistsError
+from kazoo.exceptions import NodeExistsError, NoNodeError
 from typing import Type, TypeVar, Generic
 import pytest
 import random
@@ -91,9 +91,12 @@ class TestZookeeperClient:
 
     def test_get_path_with_not_exist_path(self, zk_cli: Generic[_BaseZookeeperClientType]):
         # Test with a path which doesn't exist ---> function should
-        _zk_path = zk_cli.get_node(path=Test_Zookeeper_Not_Exist_Path)
-        assert _zk_path.path is Test_Zookeeper_Not_Exist_Path, f"The path of *ZookeeperPath* should be equal to {Test_Zookeeper_Not_Exist_Path}."
-        assert _zk_path.value is None, "The value of *ZookeeperPath* should be None because it doesn't exist recently."
+        try:
+            _zk_path = zk_cli.get_node(path=Test_Zookeeper_Not_Exist_Path)
+        except NoNodeError:
+            assert True, "Work finely."
+        else:
+            assert False, "It should raise an exception 'NoNodeError'."
 
     @_remove_path_finally
     def test_create_path_without_value(self, zk_cli: Generic[_BaseZookeeperClientType]):
@@ -210,9 +213,13 @@ class TestZookeeperClient:
 
         _creating_result = zk_cli.delete_node(path=Test_Zookeeper_Path)
 
-        _zk_path = zk_cli.get_node(path=Test_Zookeeper_Path)
-        assert _zk_path.path == Test_Zookeeper_Path, f"The path of *ZookeeperPath* should be equal to {Test_Zookeeper_Path}."
-        assert _zk_path.value is None, "The value of *ZookeeperPath* should be None because the path be deleted."
+        try:
+            _zk_path = zk_cli.get_node(path=Test_Zookeeper_Path)
+        except NoNodeError:
+            assert True, "Work finely."
+        else:
+            assert False, "It should raise an exception 'NoNodeError'."
+
 
 
 class TestZookeeperListener:

--- a/test/integration_test/_zk_testsuite.py
+++ b/test/integration_test/_zk_testsuite.py
@@ -17,8 +17,8 @@ class ZK:
         def _(test_item):
             def _(self, uit_object: Generic[_ZookeeperCrawlerType]):
                 # Delete target node in Zookeeper to guarantee that the runtime environment is clean.
-                if self._PyTest_ZK_Client.exists(path=path) is not None:
-                    self._PyTest_ZK_Client.delete(path=path)
+                if self._exist_node(path=path) is not None:
+                    self._delete_node(path=path)
                 test_item(self, uit_object)
             return _
         return _
@@ -28,7 +28,7 @@ class ZK:
         def _(test_item):
             def _(self, uit_object: Generic[_ZookeeperCrawlerType]):
                 # Create new node in Zookeeper
-                self._PyTest_ZK_Client.create(path=path, makepath=True, include_data=False)
+                self._create_node(path=path, include_data=False)
                 test_item(self, uit_object)
             return _
         return _
@@ -38,18 +38,18 @@ class ZK:
         def _(test_item):
             def _(self, uit_object: Generic[_ZookeeperCrawlerType]):
                 # Add new node with value in Zookeeper
-                if self._PyTest_ZK_Client.exists(path=path):
+                if self._exist_node(path=path):
                     if type(value) is str:
-                        self._PyTest_ZK_Client.set(path=path, value=value)
+                        self._set_value_to_node(path=path, value=value)
                     elif type(value) is bytes:
-                        self._PyTest_ZK_Client.set(path=path, value=value.encode("utf-8"))
+                        self._set_value_to_node(path=path, value=value.encode("utf-8"))
                     else:
                         raise TypeError("It only support type *str* and *bytes*.")
                 else:
                     if type(value) is str:
-                        self._PyTest_ZK_Client.create(path=path, value=bytes(value, "utf-8"), makepath=True, include_data=True)
+                        self._create_node(path=path, value=bytes(value, "utf-8"), include_data=True)
                     elif type(value) is bytes:
-                        self._PyTest_ZK_Client.create(path=path, value=value, makepath=True, include_data=True)
+                        self._create_node(path=path, value=value, include_data=True)
                     else:
                         raise TypeError("It only support type *str* and *bytes*.")
 
@@ -64,11 +64,23 @@ class ZK:
                 try:
                     test_item(self, uit_object)
                 finally:
-                    if self._PyTest_ZK_Client.exists(path=path) is not None:
+                    if self._exist_node(path=path) is not None:
                         # Remove the metadata of target path in Zookeeper
-                        self._PyTest_ZK_Client.delete(path=path)
+                        self._delete_node(path=path)
             return _
         return _
+
+    def _exist_node(self, path: str):
+        return self._PyTest_ZK_Client.exists(path=path)
+
+    def _create_node(self, path: str, value: bytes = None, include_data: bool = False) -> None:
+        self._PyTest_ZK_Client.create(path=path, value=value, makepath=True, include_data=include_data)
+
+    def _set_value_to_node(self, path: str, value: bytes) -> None:
+        self._PyTest_ZK_Client.set(path=path, value=value)
+
+    def _delete_node(self, path: str) -> None:
+        self._PyTest_ZK_Client.delete(path=path)
 
 
 class ZKTestSpec(ZK, ABC):

--- a/test/integration_test/_zk_testsuite.py
+++ b/test/integration_test/_zk_testsuite.py
@@ -64,8 +64,9 @@ class ZK:
                 try:
                     test_item(self, uit_object)
                 finally:
-                    # Remove the metadata of target path in Zookeeper
-                    self._PyTest_ZK_Client.delete(path=path)
+                    if self._PyTest_ZK_Client.exists(path=path) is not None:
+                        # Remove the metadata of target path in Zookeeper
+                        self._PyTest_ZK_Client.delete(path=path)
             return _
         return _
 

--- a/test/integration_test/_zk_testsuite.py
+++ b/test/integration_test/_zk_testsuite.py
@@ -1,6 +1,7 @@
 from smoothcrawler_cluster.crawler import ZookeeperCrawler
 from kazoo.client import KazooClient
-from typing import TypeVar, Generic, Union
+from typing import List, Dict, TypeVar, Generic, Union
+from enum import Enum
 from abc import ABC, abstractmethod
 import pytest
 
@@ -8,67 +9,107 @@ import pytest
 _ZookeeperCrawlerType = TypeVar("_ZookeeperCrawlerType", bound=ZookeeperCrawler)
 
 
+class ZKNode(Enum):
+
+    State = "state_zookeeper_path"
+    Task = "task_zookeeper_path"
+    Heartbeat = "heartbeat_zookeeper_path"
+
+
 class ZK:
 
     _PyTest_ZK_Client: KazooClient = None
 
     @staticmethod
-    def reset_testing_env(path: str):
+    def reset_testing_env(path: Union[ZKNode, List[ZKNode]]):
         def _(test_item):
             def _(self, uit_object: Generic[_ZookeeperCrawlerType]):
                 # Delete target node in Zookeeper to guarantee that the runtime environment is clean.
-                if self._exist_node(path=path) is not None:
-                    self._delete_node(path=path)
-                test_item(self, uit_object)
+                def _operate_zk(_path):
+                    if self._exist_node(path=_path) is not None:
+                        self._delete_node(path=_path)
+
+                self._operate_zk_before_run_testing(zk_crawler=uit_object, path=path, zk_function=_operate_zk, test_item=test_item)
             return _
         return _
 
     @staticmethod
-    def create_node_first(path: str):
+    def create_node_first(path: Union[ZKNode, List[ZKNode]]):
         def _(test_item):
             def _(self, uit_object: Generic[_ZookeeperCrawlerType]):
                 # Create new node in Zookeeper
-                self._create_node(path=path, include_data=False)
-                test_item(self, uit_object)
+                def _operate_zk(_path):
+                    self._create_node(path=_path, include_data=False)
+
+                self._operate_zk_before_run_testing(zk_crawler=uit_object, path=path, zk_function=_operate_zk, test_item=test_item)
             return _
         return _
 
     @staticmethod
-    def add_node_with_value_first(path: str, value: Union[str, bytes]):
+    def add_node_with_value_first(path_and_value: Dict[ZKNode, Union[str, bytes]]):
         def _(test_item):
             def _(self, uit_object: Generic[_ZookeeperCrawlerType]):
                 # Add new node with value in Zookeeper
-                if self._exist_node(path=path):
-                    if type(value) is str:
-                        self._set_value_to_node(path=path, value=value)
-                    elif type(value) is bytes:
-                        self._set_value_to_node(path=path, value=value.encode("utf-8"))
+                def _get_enum_key_from_value(_path):
+                    for _zk_node in ZKNode:
+                        if getattr(uit_object, str(_zk_node.value)) == _path:
+                            return _zk_node
                     else:
-                        raise TypeError("It only support type *str* and *bytes*.")
-                else:
-                    if type(value) is str:
-                        self._create_node(path=path, value=bytes(value, "utf-8"), include_data=True)
-                    elif type(value) is bytes:
-                        self._create_node(path=path, value=value, include_data=True)
-                    else:
-                        raise TypeError("It only support type *str* and *bytes*.")
+                        raise ValueError(f"Cannot find the mapping enum key from the value '{_path}'.")
 
-                test_item(self, uit_object)
+                def _operate_zk(_path):
+                    _key = _get_enum_key_from_value(_path)
+                    value = path_and_value[_key]
+
+                    if self._exist_node(path=_path):
+                        if type(value) is str:
+                            self._set_value_to_node(path=_path, value=bytes(value, "utf-8"))
+                        elif type(value) is bytes:
+                            self._set_value_to_node(path=_path, value=value)
+                        else:
+                            raise TypeError("It only support type *str* and *bytes*.")
+                    else:
+                        if type(value) is str:
+                            self._create_node(path=_path, value=bytes(value, "utf-8"), include_data=True)
+                        elif type(value) is bytes:
+                            self._create_node(path=_path, value=value, include_data=True)
+                        else:
+                            raise TypeError("It only support type *str* and *bytes*.")
+
+                self._operate_zk_before_run_testing(zk_crawler=uit_object, path=list(path_and_value.keys()), zk_function=_operate_zk, test_item=test_item)
             return _
         return _
 
+    def _operate_zk_before_run_testing(self, zk_crawler: Generic[_ZookeeperCrawlerType], path: Union[ZKNode, List[ZKNode]], zk_function, test_item):
+        _paths = self._paths_to_list(path)
+        for _path in _paths:
+            _path_str = getattr(zk_crawler, str(_path.value))
+            zk_function(_path_str)
+            test_item(self, zk_crawler)
+
     @staticmethod
-    def remove_node_finally(path: str):
+    def remove_node_finally(path: Union[ZKNode, List[ZKNode]]):
         def _(test_item):
             def _(self, uit_object: Generic[_ZookeeperCrawlerType]):
                 try:
                     test_item(self, uit_object)
                 finally:
-                    if self._exist_node(path=path) is not None:
-                        # Remove the metadata of target path in Zookeeper
-                        self._delete_node(path=path)
+                    _paths = self._paths_to_list(path)
+                    for _path in _paths:
+                        if self._exist_node(path=_path.value) is not None:
+                            # Remove the metadata of target path in Zookeeper
+                            self._delete_node(path=_path.value)
             return _
         return _
+
+    @classmethod
+    def _paths_to_list(cls, path: Union[ZKNode, List[ZKNode]]) -> List[ZKNode]:
+        if type(path) is list:
+            return path
+        elif type(path) is ZKNode:
+            return [path]
+        else:
+            raise TypeError("The option *path* only accept 2 data type: *ZKNode* or *List[ZKNode]*.")
 
     def _exist_node(self, path: str):
         return self._PyTest_ZK_Client.exists(path=path)

--- a/test/integration_test/crawler.py
+++ b/test/integration_test/crawler.py
@@ -10,7 +10,7 @@ import pytest
 import json
 import time
 
-from ._zk_testsuite import ZK, ZKTestSpec
+from ._zk_testsuite import ZK, ZKNode, ZKTestSpec
 from .._config import Zookeeper_Hosts
 
 
@@ -167,13 +167,12 @@ class TestZookeeperCrawler(ZKTestSpec):
         self._PyTest_ZK_Client = KazooClient(hosts=Zookeeper_Hosts)
         self._PyTest_ZK_Client.start()
 
-        _zk_crawler = ZookeeperCrawler(runner=_Runner_Value, backup=_Backup_Value, initial=False)
-        return _zk_crawler
+        return ZookeeperCrawler(runner=_Runner_Value, backup=_Backup_Value, initial=False)
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.state_zk_path)
-    @ZK.add_node_with_value_first(path=_Testing_Value.state_zk_path, value=_Testing_Value.state_data_str)
-    @ZK.remove_node_finally(path=_Testing_Value.state_zk_path)
+    @ZK.reset_testing_env(path=ZKNode.State)
+    @ZK.add_node_with_value_first(path_and_value={ZKNode.State: _Testing_Value.state_data_str})
+    @ZK.remove_node_finally(path=ZKNode.State)
     def test__get_state_from_zookeeper(self, uit_object: ZookeeperCrawler):
         _state = uit_object._get_state_from_zookeeper()
         assert type(_state) is State, _Type_Not_Correct_Assertion_Error_Message(State)
@@ -189,9 +188,9 @@ class TestZookeeperCrawler(ZKTestSpec):
             _Value_Not_Correct_Assertion_Error_Message("standby_id", _state.standby_id, _State_Standby_ID_Value)
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.task_zk_path)
-    @ZK.add_node_with_value_first(path=_Testing_Value.task_zk_path, value=_Testing_Value.task_data_str)
-    @ZK.remove_node_finally(path=_Testing_Value.task_zk_path)
+    @ZK.reset_testing_env(path=ZKNode.Task)
+    @ZK.add_node_with_value_first(path_and_value={ZKNode.Task: _Testing_Value.task_data_str})
+    @ZK.remove_node_finally(path=ZKNode.Task)
     def test__get_task_from_zookeeper(self, uit_object: ZookeeperCrawler):
         _task = uit_object._get_task_from_zookeeper()
         assert type(_task) is Task, _Type_Not_Correct_Assertion_Error_Message(Task)
@@ -201,9 +200,9 @@ class TestZookeeperCrawler(ZKTestSpec):
             _Value_Not_Correct_Assertion_Error_Message("task_content", _task.task_content, _Task_Content_Value)
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.heartbeat_zk_path)
-    @ZK.add_node_with_value_first(path=_Testing_Value.heartbeat_zk_path, value=_Testing_Value.heartbeat_data_str)
-    @ZK.remove_node_finally(path=_Testing_Value.heartbeat_zk_path)
+    @ZK.reset_testing_env(path=ZKNode.Heartbeat)
+    @ZK.add_node_with_value_first(path_and_value={ZKNode.Heartbeat: _Testing_Value.heartbeat_data_str})
+    @ZK.remove_node_finally(path=ZKNode.Heartbeat)
     def test__get_heartbeat_from_zookeeper(self, uit_object: ZookeeperCrawler):
         _heartbeat = uit_object._get_heartbeat_from_zookeeper()
         assert type(_heartbeat) is Heartbeat, _Type_Not_Correct_Assertion_Error_Message(Heartbeat)
@@ -211,36 +210,36 @@ class TestZookeeperCrawler(ZKTestSpec):
             _Value_Not_Correct_Assertion_Error_Message("datetime of heartbeat", _heartbeat.datetime, _Heartbeat_Value)
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.state_zk_path)
-    @ZK.create_node_first(path=_Testing_Value.state_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.state_zk_path)
+    @ZK.reset_testing_env(path=ZKNode.State)
+    @ZK.create_node_first(path=ZKNode.State)
+    @ZK.remove_node_finally(path=ZKNode.State)
     def test__set_state_to_zookeeper(self, uit_object: ZookeeperCrawler):
         uit_object._set_state_to_zookeeper(state=_Testing_Value.state)
         _state, _znode_state = self._get_zk_node_value(path=_Testing_Value.state_zk_path)
         assert type(_state) is not None, _Not_None_Assertion_Error
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.task_zk_path)
-    @ZK.create_node_first(path=_Testing_Value.task_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.task_zk_path)
+    @ZK.reset_testing_env(path=ZKNode.Task)
+    @ZK.create_node_first(path=ZKNode.Task)
+    @ZK.remove_node_finally(path=ZKNode.Task)
     def test__set_task_to_zookeeper(self, uit_object: ZookeeperCrawler):
         uit_object._set_task_to_zookeeper(task=_Testing_Value.task)
         _task, _znode_state = self._get_zk_node_value(path=_Testing_Value.task_zk_path)
         assert type(_task) is not None, _Not_None_Assertion_Error
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.heartbeat_zk_path)
-    @ZK.create_node_first(path=_Testing_Value.heartbeat_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.heartbeat_zk_path)
+    @ZK.reset_testing_env(path=ZKNode.Heartbeat)
+    @ZK.create_node_first(path=ZKNode.Heartbeat)
+    @ZK.remove_node_finally(path=ZKNode.Heartbeat)
     def test__set_heartbeat_to_zookeeper(self, uit_object: ZookeeperCrawler):
         uit_object._set_heartbeat_to_zookeeper(heartbeat=_Testing_Value.heartbeat)
         _heartbeat, _znode_state = self._get_zk_node_value(path=_Testing_Value.heartbeat_zk_path)
         assert type(_heartbeat) is not None, _Not_None_Assertion_Error
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.state_zk_path)
-    @ZK.add_node_with_value_first(path=_Testing_Value.state_zk_path, value=_Testing_Value.state_data_str)
-    @ZK.remove_node_finally(path=_Testing_Value.state_zk_path)
+    @ZK.reset_testing_env(path=ZKNode.State)
+    @ZK.add_node_with_value_first(path_and_value={ZKNode.State: _Testing_Value.state_data_str})
+    @ZK.remove_node_finally(path=ZKNode.State)
     def test__update_crawler_role(self, uit_object: ZookeeperCrawler):
         # Checking initial state
         _state = uit_object._get_state_from_zookeeper()
@@ -265,25 +264,20 @@ class TestZookeeperCrawler(ZKTestSpec):
             "After update the *state* meta data, the length of current crawler list should be 0 because it's *runner*."
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.state_zk_path)
-    @ZK.reset_testing_env(path=_Testing_Value.task_zk_path)
-    @ZK.reset_testing_env(path=_Testing_Value.heartbeat_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.state_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.task_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.heartbeat_zk_path)
+    @ZK.reset_testing_env(path=[ZKNode.State, ZKNode.Task, ZKNode.Heartbeat])
+    @ZK.remove_node_finally(path=[ZKNode.State, ZKNode.Task, ZKNode.Heartbeat])
     def test_register_with_not_exist_node(self, uit_object: ZookeeperCrawler):
         self.__operate_register_and_verify_result(zk_crawler=uit_object)
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.state_zk_path)
-    @ZK.reset_testing_env(path=_Testing_Value.task_zk_path)
-    @ZK.reset_testing_env(path=_Testing_Value.heartbeat_zk_path)
-    @ZK.add_node_with_value_first(path=_Testing_Value.state_zk_path, value=_Testing_Value.state_data_str)
-    @ZK.add_node_with_value_first(path=_Testing_Value.task_zk_path, value=_Testing_Value.task_data_str)
-    @ZK.add_node_with_value_first(path=_Testing_Value.heartbeat_zk_path, value=_Testing_Value.heartbeat_data_str)
-    @ZK.remove_node_finally(path=_Testing_Value.state_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.task_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.heartbeat_zk_path)
+    @ZK.reset_testing_env(path=[ZKNode.State, ZKNode.Task, ZKNode.Heartbeat])
+    @ZK.add_node_with_value_first(
+        path_and_value={
+            ZKNode.State: _Testing_Value.state_data_str,
+            ZKNode.Task: _Testing_Value.task_data_str,
+            ZKNode.Heartbeat: _Testing_Value.heartbeat_data_str
+        })
+    @ZK.remove_node_finally(path=[ZKNode.State, ZKNode.Task, ZKNode.Heartbeat])
     def test_register_with_exist_node(self, uit_object: ZookeeperCrawler):
         self.__operate_register_and_verify_result(zk_crawler=uit_object)
 
@@ -322,12 +316,8 @@ class TestZookeeperCrawler(ZKTestSpec):
         assert _heartbeat_json["datetime"] is not None, _assertion
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.state_zk_path)
-    @ZK.reset_testing_env(path=_Testing_Value.task_zk_path)
-    @ZK.reset_testing_env(path=_Testing_Value.heartbeat_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.state_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.task_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.heartbeat_zk_path)
+    @ZK.reset_testing_env(path=[ZKNode.State, ZKNode.Task, ZKNode.Heartbeat])
+    @ZK.remove_node_finally(path=[ZKNode.State, ZKNode.Task, ZKNode.Heartbeat])
     def test_is_ready_with_positive_timeout(self, uit_object: ZookeeperCrawler):
         # Operate target method to test
         uit_object.register()
@@ -338,15 +328,11 @@ class TestZookeeperCrawler(ZKTestSpec):
         # Verify the values
         assert _result is False, "It should be *False* because the property *current_crawler* size is still only 1."
         assert _Waiting_Time <= (_func_end__time - _func_start_time) < (_Waiting_Time + 1), \
-            f"The function running time should be done about {_Waiting_Time} - {Waiting_Time + 1} seconds."
+            f"The function running time should be done about {_Waiting_Time} - {_Waiting_Time + 1} seconds."
 
 
-    @ZK.reset_testing_env(path=_Testing_Value.state_zk_path)
-    @ZK.reset_testing_env(path=_Testing_Value.task_zk_path)
-    @ZK.reset_testing_env(path=_Testing_Value.heartbeat_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.state_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.task_zk_path)
-    @ZK.remove_node_finally(path=_Testing_Value.heartbeat_zk_path)
+    @ZK.reset_testing_env(path=[ZKNode.State, ZKNode.Task, ZKNode.Heartbeat])
+    @ZK.remove_node_finally(path=[ZKNode.State, ZKNode.Task, ZKNode.Heartbeat])
     def test_elect(self, uit_object: ZookeeperCrawler):
         # Operate target method to test
         uit_object.register()

--- a/test/unit_test/crawler.py
+++ b/test/unit_test/crawler.py
@@ -11,19 +11,22 @@ class TestZookeeperCrawler:
 
     @pytest.fixture(scope="function")
     def zk_crawler(self) -> ZookeeperCrawler:
-        return ZookeeperCrawler(runner=_Runner_Value, backup=_Backup_Value)
+        return ZookeeperCrawler(runner=_Runner_Value, backup=_Backup_Value, initial=False)
 
     def test_property_state_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
         _path = zk_crawler.state_zookeeper_path
-        _search_char_result = re.search(r"smoothcrawler/node/\w{1,64}/state", str(_path))
+        assert _path is not None, "The path value should not be None."
+        _search_char_result = re.search(r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/state", str(_path))
         assert _search_char_result is not None, "Its format is not correct. It should be like 'smoothcrawler/node/<crawler name>/state'."
 
     def test_property_task_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
         _path = zk_crawler.task_zookeeper_path
-        _search_char_result = re.search(r"smoothcrawler/node/\w{1,64}/task", str(_path))
+        assert _path is not None, "The path value should not be None."
+        _search_char_result = re.search(r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/task", str(_path))
         assert _search_char_result is not None, "Its format is not correct. It should be like 'smoothcrawler/node/<crawler name>/task'."
 
     def test_property_heartbeat_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
         _path = zk_crawler.heartbeat_zookeeper_path
-        _search_char_result = re.search(r"smoothcrawler/node/\w{1,64}/heartbeat", str(_path))
+        assert _path is not None, "The path value should not be None."
+        _search_char_result = re.search(r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/heartbeat", str(_path))
         assert _search_char_result is not None, "Its format is not correct. It should be like 'smoothcrawler/node/<crawler name>/heartbeat'."

--- a/test/unit_test/crawler.py
+++ b/test/unit_test/crawler.py
@@ -1,9 +1,15 @@
 from smoothcrawler_cluster.crawler import ZookeeperCrawler
+from smoothcrawler_cluster.model.metadata import State, Task, Heartbeat
+from smoothcrawler_cluster.model.metadata_enum import CrawlerStateRole, TaskResult
 import pytest
-import re
+
+from .._assertion import (
+    WorkingTime,
+    ObjectIsNoneOrNotAssertion, ValueAssertion, ListSizeAssertion, ValueFormatAssertion
+)
 
 
-_Runner_Value: int = 3
+_Runner_Value: int = 2
 _Backup_Value: int = 1
 
 
@@ -14,19 +20,97 @@ class TestZookeeperCrawler:
         return ZookeeperCrawler(runner=_Runner_Value, backup=_Backup_Value, initial=False)
 
     def test_property_state_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
+        # Get value by target method for testing
         _path = zk_crawler.state_zookeeper_path
-        assert _path is not None, "The path value should not be None."
-        _search_char_result = re.search(r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/state", str(_path))
-        assert _search_char_result is not None, "Its format is not correct. It should be like 'smoothcrawler/node/<crawler name>/state'."
+
+        # Verify values
+        ValueFormatAssertion(target=_path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/state")
 
     def test_property_task_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
+        # Get value by target method for testing
         _path = zk_crawler.task_zookeeper_path
-        assert _path is not None, "The path value should not be None."
-        _search_char_result = re.search(r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/task", str(_path))
-        assert _search_char_result is not None, "Its format is not correct. It should be like 'smoothcrawler/node/<crawler name>/task'."
+
+        # Verify values
+        ValueFormatAssertion(target=_path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/task")
 
     def test_property_heartbeat_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
+        # Get value by target method for testing
         _path = zk_crawler.heartbeat_zookeeper_path
-        assert _path is not None, "The path value should not be None."
-        _search_char_result = re.search(r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/heartbeat", str(_path))
-        assert _search_char_result is not None, "Its format is not correct. It should be like 'smoothcrawler/node/<crawler name>/heartbeat'."
+
+        # Verify values
+        ValueFormatAssertion(target=_path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/heartbeat")
+
+    def test__initial_state(self, zk_crawler: ZookeeperCrawler):
+        # Operate target method for testing
+        _state = zk_crawler._initial_state()
+
+        # Verify values
+        ObjectIsNoneOrNotAssertion(WorkingTime.AtInitial, _state, is_none=False)
+
+        ValueAssertion(WorkingTime.AtInitial, _state, metadata="role", expected_value=CrawlerStateRole.Initial.value)
+
+        ValueAssertion(WorkingTime.AtInitial, _state, metadata="total_crawler", expected_value=_Runner_Value + _Backup_Value)
+        ValueAssertion(WorkingTime.AtInitial, _state, metadata="total_runner", expected_value=_Runner_Value)
+        ValueAssertion(WorkingTime.AtInitial, _state, metadata="total_backup", expected_value=_Backup_Value)
+
+        ValueAssertion(WorkingTime.AtInitial, _state, metadata="standby_id", expected_value="0")
+
+        ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="current_crawler", expected_value=1)
+        assert _state.current_crawler[0] == zk_crawler._crawler_name, \
+            f"In initialing process, meta data *state.current_crawler* should save value '{zk_crawler._crawler_name}'."
+        ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="current_runner", expected_value=0)
+        ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="current_backup", expected_value=0)
+
+        ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="fail_crawler", expected_value=0)
+        ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="fail_runner", expected_value=0)
+        ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="fail_backup", expected_value=0)
+
+    def test__update_state(self, zk_crawler: ZookeeperCrawler):
+        # Operate target method for testing
+        _state = State()
+        _updated_state = zk_crawler._update_state(_state)
+
+        # Verify values
+        ValueAssertion(WorkingTime.AfterUpdateInInitial, _updated_state, metadata="role", expected_value=CrawlerStateRole.Initial.value)
+
+        ValueAssertion(WorkingTime.AfterUpdateInInitial, _updated_state, metadata="total_crawler", expected_value=_Runner_Value + _Backup_Value)
+        ValueAssertion(WorkingTime.AfterUpdateInInitial, _updated_state, metadata="total_runner", expected_value=_Runner_Value)
+        ValueAssertion(WorkingTime.AfterUpdateInInitial, _updated_state, metadata="total_backup", expected_value=_Backup_Value)
+
+        ValueAssertion(WorkingTime.AfterUpdateInInitial, _updated_state, metadata="standby_id", expected_value="0")
+
+        ListSizeAssertion(WorkingTime.AfterUpdateInInitial, _updated_state, metadata="current_crawler", expected_value=1)
+        assert _updated_state.current_crawler[0] == zk_crawler._crawler_name, \
+            f"In initialing process, meta data *state.current_crawler* should save value '{zk_crawler._crawler_name}'."
+
+    def test__initial_task(self, zk_crawler: ZookeeperCrawler):
+        # Operate target method for testing
+        _task = zk_crawler._initial_task()
+
+        # Verify values
+        ValueAssertion(WorkingTime.AtInitial, _task, metadata="task_result", expected_value=TaskResult.Nothing.value)
+        ValueAssertion(WorkingTime.AtInitial, _task, metadata="task_content", expected_value={})
+
+    def test__update_task(self, zk_crawler: ZookeeperCrawler):
+        # Operate target method for testing
+        _task = Task()
+        _updated_task = zk_crawler._update_task(_task)
+
+        # Verify values
+        ValueAssertion(WorkingTime.AfterUpdateInInitial, _updated_task, metadata="task_result", expected_value=TaskResult.Nothing.value)
+        ValueAssertion(WorkingTime.AfterUpdateInInitial, _updated_task, metadata="task_content", expected_value={})
+
+    def test__initial_heartbeat(self, zk_crawler: ZookeeperCrawler):
+        # Operate target method for testing
+        _heartbeat = zk_crawler._initial_heartbeat()
+
+        # Verify value
+        ObjectIsNoneOrNotAssertion(WorkingTime.AtInitial, _heartbeat, is_none=False)
+
+    def test__update_heartbeat(self, zk_crawler: ZookeeperCrawler):
+        # Operate target method for testing
+        _heartbeat = Heartbeat()
+        _updated_heartbeat = zk_crawler._update_heartbeat(_heartbeat)
+
+        # Verify value
+        ObjectIsNoneOrNotAssertion(WorkingTime.AfterUpdateInInitial, _updated_heartbeat, is_none=False)


### PR DESCRIPTION
### _Target_

* Finish 3 new features _register_, _is_ready_ and _elect_ of module **_crawler_**.


### _Modify Code Scope_

* Source code
    * Module _smoothcrawler_cluster.crawler_
    * Module _smoothcrawler_cluster.election_
    * Module _smoothcrawler_cluster.\_utils.zookeeper_

* Testing code
    * Unit Test
        * Module _crawler_
        * Module _\_utils.zookeeper_

    * Integration Test
        * Module _crawler_


### _Effecting Scope_

* Zookeeper:
    * Breaking change
        * _get_node_: Modify the implementation so that it would raises any exception outside directly.

* Others:
    * Nothing, they're new features of module **_crawler_**.


### _Description_

* Add new features in module **_crawler_**.
    * _role_: The role of crawler instance in cluster.
    * _ensure_register_: It ensures that register meta data to Zookeeper correctly.
    * _ensure_timeout_: The timeout to check meta data.
    * _ensure_wait_: How long it sleeps to check meta data next time.
    * _register_: Register the meta data to Zookeeper.
    * _is_ready_: Get the checksum the crawler instance is ready for working.
    * _elect_: Running an election to filter which crawler instance is _Runner_ and another one is _Backup_.
    * _\_empty_state_: Generate a **State** meta data object with empty value.
    * _\_update_crawler_role_: Update the *State* meta data by cluster role.

* Add 2 new integration testing for _register_, _is_ready_ and _elect_:
    * Running 3 features _register_, _is_ready_ and _elect_ by calling them.
    * Running 3 features _register_, _is_ready_ and _elect_ by the initial process with option _initial_ of **ZookeeperCrawler** object.

