### PR TITLE
🎉🎊🍾🔬🧪🧬 [New Feature + Refactor] (code + test) Add new data object 'NodeState' and refactor original 'State' to be 'GroupState'

### DIFF
--- a/smoothcrawler_cluster/model/metadata.py
+++ b/smoothcrawler_cluster/model/metadata.py
@@ -40,7 +40,6 @@ class GroupState(_BaseMetaData):
     * Example info at node *state*:
 
     {
-        "role": "runner",
         "total_crawler": 3,
         "total_runner": 2,
         "total_backup": 1,
@@ -54,8 +53,6 @@ class GroupState(_BaseMetaData):
     }
 
     """
-
-    _role: CrawlerStateRole = None
 
     _total_crawlers: int = None
     _total_runner: int = None
@@ -73,7 +70,6 @@ class GroupState(_BaseMetaData):
 
     def to_readable_object(self) -> dict:
         _dict_format_data = {
-            "role": self._role,
             "total_crawler": self.total_crawler,
             "total_runner": self.total_runner,
             "total_backup": self.total_backup,
@@ -86,33 +82,6 @@ class GroupState(_BaseMetaData):
             "fail_backup": self.fail_backup
         }
         return _dict_format_data
-
-    @property
-    def role(self) -> CrawlerStateRole:
-        """
-        Role of *SmoothCrawler-Cluster*. It recommends that use enum object **CrawlerStateRole** to configure this
-        property. But it still could use string type value ('runner', 'backup-runner', 'dead-runner', 'dead-backup-runner')
-        to do it.
-
-        :return: The enumerate object *CrawlerStateRole* or string type value.
-        """
-
-        return self._role
-
-    @role.setter
-    def role(self, role: Union[CrawlerStateRole, str]) -> None:
-        if type(role) is str:
-            _enum_values = list(map(lambda a: a.value, CrawlerStateRole))
-            if role not in _enum_values:
-                raise ValueError("The value of attribute *role* is incorrect. It recommends that using enum object "
-                                 f"*CrawlerStateRole*, but you also could use string which is valid if it in list {_enum_values}.")
-        else:
-            if type(role) is not CrawlerStateRole:
-                raise ValueError(
-                    "The value of attribute *role* is incorrect. Please use enum object *CrawlerStateRole*.")
-
-        role = role.value if type(role) is CrawlerStateRole else role
-        self._role = role
 
     @property
     def total_crawler(self) -> int:
@@ -274,6 +243,77 @@ class GroupState(_BaseMetaData):
         if type(fail_backup) is not list:
             raise ValueError("Property *fail_backup* only accept list type value.")
         self._fail_backup = fail_backup
+
+
+class NodeState(_BaseMetaData):
+    """
+    _GroupState_ is a state info for multiple nodes which also in same **group**. _NodeState_ is the state info for one
+    specific crawler instance. It would save some more detail info of the crawler instance of the cluster.
+
+    * Zookeeper node path:
+
+    /smoothcrawler/node/<crawler name>/state/
+
+
+    * Example info at node *state*:
+
+    {
+        "role": "runner",
+        "group": "sc-crawler-cluster"
+    }
+
+    """
+
+    _group: str = None
+    _role: CrawlerStateRole = None
+
+    def to_readable_object(self) -> dict:
+        return {
+            "group": self.group,
+            "role": self._role
+        }
+
+    @property
+    def group(self) -> str:
+        """
+        The name of group current crawler instance in.
+
+        :return: group name.
+        """
+        return self._group
+
+    @group.setter
+    def group(self, group: str) -> None:
+        if type(group) is not str:
+            raise ValueError("Property *group* only accept 'str' type value.")
+        self._group = group
+
+    @property
+    def role(self) -> CrawlerStateRole:
+        """
+        Role of *SmoothCrawler-Cluster*. It recommends that use enum object **CrawlerStateRole** to configure this
+        property. But it still could use string type value ('runner', 'backup-runner', 'dead-runner', 'dead-backup-runner')
+        to do it.
+
+        :return: The enumerate object *CrawlerStateRole* or string type value.
+        """
+
+        return self._role
+
+    @role.setter
+    def role(self, role: Union[CrawlerStateRole, str]) -> None:
+        if type(role) is str:
+            _enum_values = list(map(lambda a: a.value, CrawlerStateRole))
+            if role not in _enum_values:
+                raise ValueError("The value of attribute *role* is incorrect. It recommends that using enum object "
+                                 f"*CrawlerStateRole*, but you also could use string which is valid if it in list {_enum_values}.")
+        else:
+            if type(role) is not CrawlerStateRole:
+                raise ValueError(
+                    "The value of attribute *role* is incorrect. Please use enum object *CrawlerStateRole*.")
+
+        role = role.value if type(role) is CrawlerStateRole else role
+        self._role = role
 
 
 class Task(_BaseMetaData):

--- a/test/_values.py
+++ b/test/_values.py
@@ -2,7 +2,7 @@
 Here are some global variables for testing.
 """
 
-from smoothcrawler_cluster.model import CrawlerStateRole, TaskResult, HeartState, GroupState, Task, Heartbeat
+from smoothcrawler_cluster.model import CrawlerStateRole, TaskResult, HeartState, GroupState, NodeState, Task, Heartbeat
 from datetime import datetime
 
 
@@ -17,6 +17,7 @@ Test_Zookeeper_Bytes_Value = b"This is test value in zookeeper"
 
 # # # # For feature related crawler
 # # Related state settings
+_Crawler_Group_Name_Value: str = "sc-crawler-cluster"
 _Crawler_Name_Value: str = "sc-crawler_1"
 _Crawler_Role_Value: str = CrawlerStateRole.Initial.value
 _Runner_Crawler_Value: int = 2
@@ -46,9 +47,8 @@ def generate_crawler_list(index: int) -> list:
 
 
 # # # # For data objects: *State*, *Task*, *Heartbeat*
-# # *State*
-_Test_State_Data = {
-    "role": _Crawler_Role_Value,
+# # *GroupState*
+_Test_Group_State_Data = {
     "total_crawler": _Total_Crawler_Value,
     "total_runner": _Runner_Crawler_Value,
     "total_backup": _Backup_Crawler_Value,
@@ -59,6 +59,12 @@ _Test_State_Data = {
     "fail_crawler": _Empty_List_Value,
     "fail_runner": _Empty_List_Value,
     "fail_backup": _Empty_List_Value
+}
+
+# # *NodeState*
+_Test_Node_State_Data = {
+    "group": _Crawler_Group_Name_Value,
+    "role": _Crawler_Role_Value
 }
 
 # # *Task*
@@ -79,24 +85,31 @@ _Test_Heartbeat_Data = {
 }
 
 
-def setup_state(reset: bool = False) -> GroupState:
+def setup_group_state(reset: bool = False) -> GroupState:
     _state = GroupState()
-    _state.role = _Test_State_Data["role"]
-    _state.total_crawler = _Test_State_Data["total_crawler"]
-    _state.total_runner = _Test_State_Data["total_runner"]
-    _state.total_backup = _Test_State_Data["total_backup"]
+    # _state.role = _Test_Group_State_Data["role"]
+    _state.total_crawler = _Test_Group_State_Data["total_crawler"]
+    _state.total_runner = _Test_Group_State_Data["total_runner"]
+    _state.total_backup = _Test_Group_State_Data["total_backup"]
     if reset is True:
         _state.current_crawler = _Empty_List_Value
         _state.current_runner = _Empty_List_Value
         _state.current_backup = _Empty_List_Value
     else:
-        _state.current_crawler = _Test_State_Data["current_crawler"]
-        _state.current_runner = _Test_State_Data["current_runner"]
-        _state.current_backup = _Test_State_Data["current_backup"]
-    _state.fail_crawler = _Test_State_Data["fail_crawler"]
-    _state.fail_runner = _Test_State_Data["fail_runner"]
-    _state.fail_backup = _Test_State_Data["fail_backup"]
-    _state.standby_id = _Test_State_Data["standby_id"]
+        _state.current_crawler = _Test_Group_State_Data["current_crawler"]
+        _state.current_runner = _Test_Group_State_Data["current_runner"]
+        _state.current_backup = _Test_Group_State_Data["current_backup"]
+    _state.fail_crawler = _Test_Group_State_Data["fail_crawler"]
+    _state.fail_runner = _Test_Group_State_Data["fail_runner"]
+    _state.fail_backup = _Test_Group_State_Data["fail_backup"]
+    _state.standby_id = _Test_Group_State_Data["standby_id"]
+    return _state
+
+
+def setup_node_state() -> NodeState:
+    _state = NodeState()
+    _state.group = _Test_Node_State_Data["group"]
+    _state.role = _Test_Node_State_Data["role"]
     return _state
 
 

--- a/test/integration_test/_zk_testsuite.py
+++ b/test/integration_test/_zk_testsuite.py
@@ -11,7 +11,8 @@ _ZookeeperCrawlerType = TypeVar("_ZookeeperCrawlerType", bound=ZookeeperCrawler)
 
 class ZKNode(Enum):
 
-    State = "state_zookeeper_path"
+    GroupState = "group_state_zookeeper_path"
+    NodeState = "node_state_zookeeper_path"
     Task = "task_zookeeper_path"
     Heartbeat = "heartbeat_zookeeper_path"
 

--- a/test/unit_test/_utils/converter.py
+++ b/test/unit_test/_utils/converter.py
@@ -3,8 +3,8 @@ import pytest
 import json
 
 from ..._values import (
-    _Test_State_Data, _Test_Task_Data, _Test_Heartbeat_Data,
-    setup_state, setup_task, setup_heartbeat
+    _Test_Group_State_Data, _Test_Node_State_Data, _Test_Task_Data, _Test_Heartbeat_Data,
+    setup_group_state, setup_node_state, setup_task, setup_heartbeat
 )
 
 
@@ -16,27 +16,37 @@ class TestJsonStrConverter:
 
     def test_serialize(self, converter: JsonStrConverter):
         # Initial process
-        _state = setup_state()
+        _state = setup_group_state()
 
         # Run target testing function
         _serialized_data = converter.serialize(data=_state.to_readable_object())
 
         # Verify running result
-        self._verify_serialize_result(serialized_data=_serialized_data, expected_data=json.dumps(_Test_State_Data))
+        self._verify_serialize_result(serialized_data=_serialized_data, expected_data=json.dumps(_Test_Group_State_Data))
 
     def test_deserialize(self, converter: JsonStrConverter):
         # Run target testing function
-        _deserialized_data: dict = converter.deserialize(data=json.dumps(_Test_State_Data))
+        _deserialized_data: dict = converter.deserialize(data=json.dumps(_Test_Group_State_Data))
 
         # Verify running result
-        self._verify_deserialize_result(deserialized_data=_deserialized_data, expected_data=_Test_State_Data)
+        self._verify_deserialize_result(deserialized_data=_deserialized_data, expected_data=_Test_Group_State_Data)
 
-    def test_state_to_str(self, converter: JsonStrConverter):
+    def test_group_state_to_str(self, converter: JsonStrConverter):
         # Initial process
-        _state = setup_state()
+        _state = setup_group_state()
 
         # Run target testing function
-        _state_str = converter.state_to_str(state=_state)
+        _state_str = converter.group_state_to_str(state=_state)
+
+        # Verify running result
+        self._verify_serialize_result(serialized_data=_state_str, expected_data=json.dumps(_state.to_readable_object()))
+
+    def test_node_state_to_str(self, converter: JsonStrConverter):
+        # Initial process
+        _state = setup_node_state()
+
+        # Run target testing function
+        _state_str = converter.node_state_to_str(state=_state)
 
         # Verify running result
         self._verify_serialize_result(serialized_data=_state_str, expected_data=json.dumps(_state.to_readable_object()))
@@ -61,15 +71,25 @@ class TestJsonStrConverter:
         # Verify running result
         self._verify_serialize_result(serialized_data=_heartbeat_str, expected_data=json.dumps(_heartbeat.to_readable_object()))
 
-    def test_str_to_state(self, converter: JsonStrConverter):
+    def test_str_to_group_state(self, converter: JsonStrConverter):
         # Initial process
-        _test_state_str = json.dumps(_Test_State_Data)
+        _test_state_str = json.dumps(_Test_Group_State_Data)
 
         # Run target testing function
-        _state = converter.str_to_state(data=_test_state_str)
+        _state = converter.str_to_group_state(data=_test_state_str)
 
         # Verify running result
-        self._verify_deserialize_result(deserialized_data=_state.to_readable_object(), expected_data=_Test_State_Data)
+        self._verify_deserialize_result(deserialized_data=_state.to_readable_object(), expected_data=_Test_Group_State_Data)
+
+    def test_str_to_node_state(self, converter: JsonStrConverter):
+        # Initial process
+        _test_state_str = json.dumps(_Test_Node_State_Data)
+
+        # Run target testing function
+        _state = converter.str_to_node_state(data=_test_state_str)
+
+        # Verify running result
+        self._verify_deserialize_result(deserialized_data=_state.to_readable_object(), expected_data=_Test_Node_State_Data)
 
     def test_str_to_task(self, converter: JsonStrConverter):
         # Initial process

--- a/test/unit_test/crawler.py
+++ b/test/unit_test/crawler.py
@@ -16,12 +16,19 @@ class TestZookeeperCrawler:
             mock_zk_cli.assert_called_once()
         return _zk_crawler
 
-    def test_property_state_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
+    def test_property_group_state_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
         # Get value by target method for testing
-        _path = zk_crawler.state_zookeeper_path
+        _path = zk_crawler.group_state_zookeeper_path
 
         # Verify values
         ValueFormatAssertion(target=_path, regex=r"smoothcrawler/group/[\w\-_]{1,64}/state")
+
+    def test_property_node_state_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
+        # Get value by target method for testing
+        _path = zk_crawler.node_state_zookeeper_path
+
+        # Verify values
+        ValueFormatAssertion(target=_path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/state")
 
     def test_property_task_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
         # Get value by target method for testing

--- a/test/unit_test/model/init.py
+++ b/test/unit_test/model/init.py
@@ -11,12 +11,10 @@ class TestInitial:
 
     def test__initial_state(self):
         # Operate target method for testing
-        _state = Initial.state(crawler_name=_Crawler_Name_Value, total_crawler=_Total_Crawler_Value, total_runner=_Runner_Crawler_Value, total_backup=_Backup_Crawler_Value)
+        _state = Initial.group_state(crawler_name=_Crawler_Name_Value, total_crawler=_Total_Crawler_Value, total_runner=_Runner_Crawler_Value, total_backup=_Backup_Crawler_Value)
 
         # Verify values
         ObjectIsNoneOrNotAssertion(WorkingTime.AtInitial, _state, is_none=False)
-
-        ValueAssertion(WorkingTime.AtInitial, _state, metadata="role", expected_value=CrawlerStateRole.Initial.value)
 
         ValueAssertion(WorkingTime.AtInitial, _state, metadata="total_crawler", expected_value=_Runner_Crawler_Value + _Backup_Crawler_Value)
         ValueAssertion(WorkingTime.AtInitial, _state, metadata="total_runner", expected_value=_Runner_Crawler_Value)
@@ -33,6 +31,16 @@ class TestInitial:
         ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="fail_crawler", expected_value=0)
         ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="fail_runner", expected_value=0)
         ListSizeAssertion(WorkingTime.AtInitial, _state, metadata="fail_backup", expected_value=0)
+
+    def test__initial_node_state(self):
+        # Operate target method for testing
+        _state = Initial.node_state(group="test-group")
+
+        # Verify values
+        ObjectIsNoneOrNotAssertion(WorkingTime.AtInitial, _state, is_none=False)
+
+        ValueAssertion(WorkingTime.AtInitial, _state, metadata="group", expected_value="test-group")
+        ValueAssertion(WorkingTime.AtInitial, _state, metadata="role", expected_value=CrawlerStateRole.Initial.value)
 
     def test__initial_task(self):
         # Operate target method for testing

--- a/test/unit_test/model/metadata.py
+++ b/test/unit_test/model/metadata.py
@@ -1,4 +1,4 @@
-from smoothcrawler_cluster.model.metadata import GroupState, Task, Heartbeat
+from smoothcrawler_cluster.model.metadata import GroupState, NodeState, Task, Heartbeat
 from smoothcrawler_cluster.model.metadata_enum import CrawlerStateRole, TaskResult, HeartState
 
 from datetime import datetime
@@ -77,58 +77,11 @@ class _MetaDataTest(metaclass=ABCMeta):
 
 
 class TestGroupState(_MetaDataTest):
-    """Test for all the attributes of **State**."""
+    """Test for all the attributes of **GroupState**."""
 
     @pytest.fixture(scope="function")
     def state(self) -> GroupState:
         return GroupState()
-
-    def test_set_role_correctly(self, state: GroupState) -> None:
-        """
-        Test for the setting process should work finely without any issue because it works with normal value
-        like enum object **CrawlerStateRole** or valid string type value like ['runner', 'backup-runner',
-        'dead-runner', 'dead-backup-runner'].
-
-        :param state: The instance of the object **State** with nothing settings.
-        :return: None
-        """
-
-        # Test for setting the property normally. It would choice one value randomly.
-        _under_test_value: CrawlerStateRole = random.choice([CrawlerStateRole.Runner, CrawlerStateRole.Backup_Runner, CrawlerStateRole.Dead_Runner, CrawlerStateRole.Dead_Backup_Runner])
-        try:
-            state.role = _under_test_value
-        except Exception:
-            assert False, f"It should work finely without any issue.\n The error is: {traceback.format_exc()}"
-        else:
-            assert True, "It works finely."
-            assert state.role == _under_test_value.value, "The value should be same as it set."
-
-        _enum_values = list(map(lambda a: a.value, CrawlerStateRole))
-        _under_test_value = random.choice(_enum_values)
-        try:
-            state.role = "runner"
-        except Exception:
-            assert False, f"It should work finely without any issue.\n The error is: {traceback.format_exc()}"
-        else:
-            assert True, "It works finely."
-            assert state.role == "runner", "The value should be same as it set."
-
-    def test_set_role_incorrectly(self, state: GroupState) -> None:
-        """
-        Test for setting the property *role* with invalid string value.
-
-        :param state: The instance of the object **State** with nothing settings.
-        :return: None
-        """
-
-        # Test for setting the property with incorrect string type value.
-        try:
-            state.role = "python-hello-world"
-        except Exception:
-            assert True, "It works finely."
-            assert state.role is None, "The value should be None because it got fail when it set the value."
-        else:
-            assert False, f"It should work finely without any issue.\n The error is: {traceback.format_exc()}"
 
     def test_total_crawler(self, state: GroupState) -> None:
         """
@@ -349,6 +302,77 @@ class TestGroupState(_MetaDataTest):
             invalid_1_value="5",
             invalid_2_value={"k1": "v1", "k2": "v2", "k3": "v3"}
         )
+
+
+class TestNodeState(_MetaDataTest):
+    """Test for all the attributes of **NodeState**."""
+
+    @pytest.fixture(scope="function")
+    def state(self) -> NodeState:
+        return NodeState()
+
+    def test_group(self, state: NodeState) -> None:
+
+        def _get_func() -> str:
+            return state.group
+
+        def _set_func(value) -> None:
+            state.group = value
+
+        self._run_property_test(
+            getting_func=_get_func,
+            setting_func=_set_func,
+            valid_value="test-group",
+            invalid_1_value=5,
+            invalid_2_value={"k1": "v1", "k2": "v2", "k3": "v3"}
+        )
+
+    def test_set_role_correctly(self, state: NodeState) -> None:
+        """
+        Test for the setting process should work finely without any issue because it works with normal value
+        like enum object **CrawlerStateRole** or valid string type value like ['runner', 'backup-runner',
+        'dead-runner', 'dead-backup-runner'].
+
+        :param state: The instance of the object **State** with nothing settings.
+        :return: None
+        """
+
+        # Test for setting the property normally. It would choice one value randomly.
+        _under_test_value: CrawlerStateRole = random.choice([CrawlerStateRole.Runner, CrawlerStateRole.Backup_Runner, CrawlerStateRole.Dead_Runner, CrawlerStateRole.Dead_Backup_Runner])
+        try:
+            state.role = _under_test_value
+        except Exception:
+            assert False, f"It should work finely without any issue.\n The error is: {traceback.format_exc()}"
+        else:
+            assert True, "It works finely."
+            assert state.role == _under_test_value.value, "The value should be same as it set."
+
+        _enum_values = list(map(lambda a: a.value, CrawlerStateRole))
+        _under_test_value = random.choice(_enum_values)
+        try:
+            state.role = "runner"
+        except Exception:
+            assert False, f"It should work finely without any issue.\n The error is: {traceback.format_exc()}"
+        else:
+            assert True, "It works finely."
+            assert state.role == "runner", "The value should be same as it set."
+
+    def test_set_role_incorrectly(self, state: NodeState) -> None:
+        """
+        Test for setting the property *role* with invalid string value.
+
+        :param state: The instance of the object **State** with nothing settings.
+        :return: None
+        """
+
+        # Test for setting the property with incorrect string type value.
+        try:
+            state.role = "python-hello-world"
+        except Exception:
+            assert True, "It works finely."
+            assert state.role is None, "The value should be None because it got fail when it set the value."
+        else:
+            assert False, f"It should work finely without any issue.\n The error is: {traceback.format_exc()}"
 
 
 class TestTask(_MetaDataTest):


### PR DESCRIPTION
### _Target_

* Add new data object **_NodeState_** and refactor original **_State_** to be **_GroupState_**.
    * After deep consideration, the original meta data object **_State_** be more clear and suitable as **_GroupState_**.
    * Some attributes should be more suitable in another one new meta data object **_NodeState_**.


### _Modify Code Scope_

* Source code
    * module _crawler_
    * module _model./_/_init/_/__
    * module _model.metadata_
    * module _/_utils.converter_

* Testing code
    * Common module
        * _/_values_ 

    * Unit Testing
        * testing module _crawler_
        * testing module _model.init_
        * testing module _model.metadata_
        * testing module _/_utils.converter_

    * Integration Testing
        * common module _/_zk_testsuite_
        * testing module _crawler_


### _Effecting Scope_

* A little bit breaking changes, for all the usage of **GroupState** (original: **State**).
* Provide new feature about meta data object **NodeState**.
* But for some APIs like in _crawler_ module, nothing be effected.


### _Description_

* For sub-package _model_ in source code:
    * Add new meta data object **NodeState** and its operating common functions.

* For module _/_utils.converter_ in source code:
    * Add new serialization and deserialization of meta data object **NodeState**.

* For module crawler in source code:
    * Except the part of adding some functions about new meta data object **NodeState** and refactoring object **GroupState**, it also modify the detail of implementation about updating crawler role process.

* For common objects or functions in testing:
    * Add some global variables or functions for testing meta data **NodeState**.

* For others parts:
    * Refactoring to use **GroupState** from **State**.
    * Rename some APIs (functions) to be more clear and suitable as _xxx_group_state_xxx_ (origin: _xxx_state_xxx_).

