### PR TITLE
🔧⚙️🔩 [Breaking Change] (code + test) Modify to get attribute 'standby_id' from Zookeeper, not saving in memory of instance

### DIFF
--- a/smoothcrawler_cluster/_utils/zookeeper.py
+++ b/smoothcrawler_cluster/_utils/zookeeper.py
@@ -264,21 +264,3 @@ class ZookeeperClient(_BaseZookeeperClient):
 
     def close(self) -> None:
         self.__zk_client.close()
-
-
-class _BaseZookeeperListener(metaclass=ABCMeta):
-
-    def __init__(self, converter: BaseConverterType = None):
-        self._converter = converter
-
-    @abstractmethod
-    def watch_data(self, path: str):
-        pass
-
-    @abstractmethod
-    def listen_path_for_value(self, path: str, value: str) -> bool:
-        pass
-
-    @abstractmethod
-    def converter(self, data: str) -> Any:
-        pass

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -1,14 +1,14 @@
 from smoothcrawler.crawler import BaseCrawler
 from smoothcrawler.factory import BaseFactory
 from datetime import datetime
-from typing import List, Dict, Callable, Any, Type, TypeVar, Union, Generic
+from typing import List, Dict, Callable, Any, Type, TypeVar, Generic
 from abc import ABCMeta
 import threading
 import time
 
 from .model import (
     # Zookeeper operating common functions
-    Empty, Initial, Update,
+    Initial, Update,
     # Enum objects
     CrawlerStateRole, TaskResult, HeartState,
     # Content data namedtuple object

--- a/test/integration_test/_utils/zookeeper.py
+++ b/test/integration_test/_utils/zookeeper.py
@@ -15,7 +15,6 @@ from ..._values import Test_Zookeeper_Path, Test_Zookeeper_Not_Exist_Path, Test_
 
 _BaseZookeeperPathType = TypeVar("_BaseZookeeperPathType", bound=_BaseZookeeperNode)
 _BaseZookeeperClientType = TypeVar("_BaseZookeeperClientType", bound=_BaseZookeeperClient)
-_BaseZookeeperListenerType = TypeVar("_BaseZookeeperListenerType", bound=_BaseZookeeperListener)
 
 
 class TestZookeeperClient:

--- a/test/integration_test/_utils/zookeeper.py
+++ b/test/integration_test/_utils/zookeeper.py
@@ -1,8 +1,7 @@
 from smoothcrawler_cluster._utils.zookeeper import (
     _BaseZookeeperNode,
     ZookeeperRecipe,
-    _BaseZookeeperClient, ZookeeperClient,
-    _BaseZookeeperListener
+    _BaseZookeeperClient, ZookeeperClient
 )
 from kazoo.client import KazooClient
 from kazoo.exceptions import NodeExistsError, NoNodeError
@@ -191,10 +190,3 @@ class TestZookeeperClient:
         else:
             assert False, "It should raise an exception 'NoNodeError'."
 
-
-
-class TestZookeeperListener:
-
-    @pytest.fixture(scope="function")
-    def zk_listener(self) -> Type[_BaseZookeeperListener]:
-        return

--- a/test/integration_test/crawler.py
+++ b/test/integration_test/crawler.py
@@ -548,7 +548,8 @@ class TestZookeeperCrawler(ZKTestSpec):
 
         def _update_state_standby_id():
             time.sleep(5)
-            setattr(_zk_crawler, "_standby_id", "2")
+            _state.standby_id = "2"
+            _zk_crawler._MetaData_Util.set_metadata_to_zookeeper(path=_zk_crawler.group_state_zookeeper_path, metadata=_state)
 
         def _run_target_test_func():
             try:


### PR DESCRIPTION
### _Target_

* Modify to get attribute _standby_id_ from Zookeeper, not saving in memory of instance.
* Remove some unused code or doesn't support feature.


### _Modify Code Scope_

* Source Code
    * module _crawler_
    * module _\_utils.zookeeper_

* Testing Code
    * Integration Testing
        * testing module _crawler_


### _Effecting Scope_

* For outside usage, nothing. The major change in this PR for the implementation detail. So the effect for the Zookeeper operating, doesn't for the outside.


### _Description_

* Modify to get meta-data attribute _standby_id_ from Zookeeper, doesn't saving it in memory by instance.
    * To ensure that the value of meta-data is latest and manage it by Zookeeper.
