### PR TITLE
🔬🧪🧬 [Refactor] (code + test) Move the properties about Zookeeper node path to another new object.

### DIFF
--- a/docs/smoothcrawler_cluster/api_references/inner_modules/zookeeper.rst
+++ b/docs/smoothcrawler_cluster/api_references/inner_modules/zookeeper.rst
@@ -7,6 +7,14 @@ Utils - Zookeeper
 .. automodule:: smoothcrawler_cluster._utils.zookeeper
 
 
+ZookeeperPath
+--------------
+
+.. autoclass:: smoothcrawler_cluster._utils.zookeeper.ZookeeperPath
+    :members:
+
+
+
 ZookeeperNode
 --------------
 

--- a/smoothcrawler_cluster/_utils/__init__.py
+++ b/smoothcrawler_cluster/_utils/__init__.py
@@ -16,6 +16,7 @@ from .converter import BaseConverter, JsonStrConverter, TaskContentDataUtils
 from .zookeeper import (
     ZookeeperClient,
     ZookeeperNode,
+    ZookeeperPath,
     ZookeeperRecipe,
     _BaseZookeeperClient,
     _BaseZookeeperNode,

--- a/smoothcrawler_cluster/_utils/zookeeper.py
+++ b/smoothcrawler_cluster/_utils/zookeeper.py
@@ -49,6 +49,63 @@ class _BaseZookeeperNode(metaclass=ABCMeta):
         pass
 
 
+class ZookeeperPath:
+    """*All paths of Zookeeper*
+
+    In Zookeeper, it would save data under specific path as node. This object provides all paths of Zookeeper which
+    saves meta-data for *SmoothCrawler-Cluster*.
+    """
+
+    _group_state_node: str = "state"
+    _node_state_node: str = "state"
+    _task_node: str = "task"
+    _heartbeat_node: str = "heartbeat"
+
+    def __init__(self, name: str = None, group: str = None):
+        self._name = name
+        self._group = group
+
+    @property
+    def group_state_zookeeper_path(self) -> str:
+        # pylint: disable-next=line-too-long
+        """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **GroupState** in Zookeeper."""
+        return f"{self.generate_path(self._group, is_group=True)}/{self._group_state_node}"
+
+    @property
+    def node_state_zookeeper_path(self) -> str:
+        # pylint: disable-next=line-too-long
+        """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **NodeState** in Zookeeper."""
+        return f"{self.generate_path(self._name)}/{self._node_state_node}"
+
+    @property
+    def task_zookeeper_path(self) -> str:
+        """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **Task** in Zookeeper."""
+        return f"{self.generate_path(self._name)}/{self._task_node}"
+
+    @property
+    def heartbeat_zookeeper_path(self) -> str:
+        # pylint: disable-next=line-too-long
+        """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **Heartbeat** in Zookeeper."""
+        return f"{self.generate_path(self._name)}/{self._heartbeat_node}"
+
+    @classmethod
+    def generate_path(cls, crawler_name: str, is_group: bool = False) -> str:
+        """Generate node path of Zookeeper with fixed format.
+
+        Args:
+            crawler_name (str): The crawler name.
+            is_group (bool): If it's True, generate node path for _group_ type meta-data.
+
+        Returns:
+            str: A Zookeeper node path.
+
+        """
+        if is_group:
+            return f"smoothcrawler/group/{crawler_name}"
+        else:
+            return f"smoothcrawler/node/{crawler_name}"
+
+
 class ZookeeperNode(_BaseZookeeperNode):
     """*Zookeeper node object*
 

--- a/smoothcrawler_cluster/_utils/zookeeper.py
+++ b/smoothcrawler_cluster/_utils/zookeeper.py
@@ -61,7 +61,7 @@ class ZookeeperPath:
     _task_node: str = "task"
     _heartbeat_node: str = "heartbeat"
 
-    def __init__(self, name: str = None, group: str = None):
+    def __init__(self, name: str, group: str):
         self._name = name
         self._group = group
 

--- a/smoothcrawler_cluster/_utils/zookeeper.py
+++ b/smoothcrawler_cluster/_utils/zookeeper.py
@@ -69,27 +69,27 @@ class ZookeeperPath:
     def group_state(self) -> str:
         # pylint: disable-next=line-too-long
         """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **GroupState** in Zookeeper."""
-        return f"{self.generate_path(self._group, is_group=True)}/{self._group_state_node}"
+        return f"{self.generate_parent_node(self._group, is_group=True)}/{self._group_state_node}"
 
     @property
     def node_state(self) -> str:
         # pylint: disable-next=line-too-long
         """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **NodeState** in Zookeeper."""
-        return f"{self.generate_path(self._name)}/{self._node_state_node}"
+        return f"{self.generate_parent_node(self._name)}/{self._node_state_node}"
 
     @property
     def task(self) -> str:
         """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **Task** in Zookeeper."""
-        return f"{self.generate_path(self._name)}/{self._task_node}"
+        return f"{self.generate_parent_node(self._name)}/{self._task_node}"
 
     @property
     def heartbeat(self) -> str:
         # pylint: disable-next=line-too-long
         """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **Heartbeat** in Zookeeper."""
-        return f"{self.generate_path(self._name)}/{self._heartbeat_node}"
+        return f"{self.generate_parent_node(self._name)}/{self._heartbeat_node}"
 
     @classmethod
-    def generate_path(cls, crawler_name: str, is_group: bool = False) -> str:
+    def generate_parent_node(cls, crawler_name: str, is_group: bool = False) -> str:
         """Generate node path of Zookeeper with fixed format.
 
         Args:

--- a/smoothcrawler_cluster/_utils/zookeeper.py
+++ b/smoothcrawler_cluster/_utils/zookeeper.py
@@ -66,24 +66,24 @@ class ZookeeperPath:
         self._group = group
 
     @property
-    def group_state_zookeeper_path(self) -> str:
+    def group_state(self) -> str:
         # pylint: disable-next=line-too-long
         """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **GroupState** in Zookeeper."""
         return f"{self.generate_path(self._group, is_group=True)}/{self._group_state_node}"
 
     @property
-    def node_state_zookeeper_path(self) -> str:
+    def node_state(self) -> str:
         # pylint: disable-next=line-too-long
         """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **NodeState** in Zookeeper."""
         return f"{self.generate_path(self._name)}/{self._node_state_node}"
 
     @property
-    def task_zookeeper_path(self) -> str:
+    def task(self) -> str:
         """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **Task** in Zookeeper."""
         return f"{self.generate_path(self._name)}/{self._task_node}"
 
     @property
-    def heartbeat_zookeeper_path(self) -> str:
+    def heartbeat(self) -> str:
         # pylint: disable-next=line-too-long
         """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **Heartbeat** in Zookeeper."""
         return f"{self.generate_path(self._name)}/{self._heartbeat_node}"

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -701,7 +701,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
 
         def _one_current_runner_is_dead(runner_name: str) -> Optional[str]:
             current_runner_heartbeat = self._metadata_util.get_metadata_from_zookeeper(
-                path=f"{self._zk_path.generate_path(runner_name)}/{self._zookeeper_heartbeat_node_path}",
+                path=f"{self._zk_path.generate_parent_node(runner_name)}/{self._zookeeper_heartbeat_node_path}",
                 as_obj=Heartbeat,
             )
 
@@ -736,7 +736,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                 # Only handle the first one of dead crawlers (if it has multiple dead crawlers
                 runner_name = dead_current_runner[0]
                 heartbeat = self._metadata_util.get_metadata_from_zookeeper(
-                    path=f"{self._zk_path.generate_path(runner_name)}/{self._zookeeper_heartbeat_node_path}",
+                    path=f"{self._zk_path.generate_parent_node(runner_name)}/{self._zookeeper_heartbeat_node_path}",
                     as_obj=Heartbeat,
                 )
                 task_of_dead_crawler = self.discover(dead_crawler_name=runner_name, heartbeat=heartbeat)
@@ -888,18 +888,21 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             Task: Meta-data **Task** from dead crawler instance.
 
         """
-        node_state_path = f"{self._zk_path.generate_path(dead_crawler_name)}/{self._zookeeper_node_state_node_path}"
+        node_state_path = (
+            f"{self._zk_path.generate_parent_node(dead_crawler_name)}/{self._zookeeper_node_state_node_path}"
+        )
         node_state = self._metadata_util.get_metadata_from_zookeeper(path=node_state_path, as_obj=NodeState)
         node_state.role = CrawlerStateRole.DEAD_RUNNER
         self._metadata_util.set_metadata_to_zookeeper(path=node_state_path, metadata=node_state)
 
         task = self._metadata_util.get_metadata_from_zookeeper(
-            path=f"{self._zk_path.generate_path(dead_crawler_name)}/{self._zookeeper_task_node_path}", as_obj=Task
+            path=f"{self._zk_path.generate_parent_node(dead_crawler_name)}/{self._zookeeper_task_node_path}",
+            as_obj=Task,
         )
         heartbeat.healthy_state = HeartState.ASYSTOLE
         heartbeat.task_state = task.running_status
         self._metadata_util.set_metadata_to_zookeeper(
-            path=f"{self._zk_path.generate_path(dead_crawler_name)}/{self._zookeeper_heartbeat_node_path}",
+            path=f"{self._zk_path.generate_parent_node(dead_crawler_name)}/{self._zookeeper_heartbeat_node_path}",
             metadata=heartbeat,
         )
 

--- a/smoothcrawler_cluster/crawler.py
+++ b/smoothcrawler_cluster/crawler.py
@@ -16,7 +16,7 @@ from smoothcrawler.factory import BaseFactory
 
 from ._utils import MetaDataUtil, parse_timer
 from ._utils.converter import BaseConverter, JsonStrConverter, TaskContentDataUtils
-from ._utils.zookeeper import ZookeeperClient, ZookeeperRecipe
+from ._utils.zookeeper import ZookeeperClient, ZookeeperPath, ZookeeperRecipe
 from .election import BaseElection, ElectionResult, IndexElection
 from .model import (
     CrawlerStateRole,
@@ -157,6 +157,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             zk_hosts = self._default_zookeeper_hosts
         self._zk_hosts = zk_hosts
         self._zookeeper_client = ZookeeperClient(hosts=self._zk_hosts)
+        self._zk_path = ZookeeperPath(name=self._crawler_name, group=self._crawler_group)
 
         if not zk_converter:
             zk_converter = JsonStrConverter()
@@ -251,46 +252,6 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
     def ensure_wait(self, wait: int) -> None:
         self._ensure_wait = wait
 
-    @property
-    def group_state_zookeeper_path(self) -> str:
-        # pylint: disable-next=line-too-long
-        """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **GroupState** in Zookeeper."""
-        return f"{self._generate_path(self._crawler_group, is_group=True)}/{self._zookeeper_group_state_node_path}"
-
-    @property
-    def node_state_zookeeper_path(self) -> str:
-        # pylint: disable-next=line-too-long
-        """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **NodeState** in Zookeeper."""
-        return f"{self._generate_path(self._crawler_name)}/{self._zookeeper_node_state_node_path}"
-
-    @property
-    def task_zookeeper_path(self) -> str:
-        """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **Task** in Zookeeper."""
-        return f"{self._generate_path(self._crawler_name)}/{self._zookeeper_task_node_path}"
-
-    @property
-    def heartbeat_zookeeper_path(self) -> str:
-        # pylint: disable-next=line-too-long
-        """:obj:`str`: Properties with both a getter and setter. The node path of meta-data **Heartbeat** in Zookeeper."""
-        return f"{self._generate_path(self._crawler_name)}/{self._zookeeper_heartbeat_node_path}"
-
-    @classmethod
-    def _generate_path(cls, crawler_name: str, is_group: bool = False) -> str:
-        """Generate node path of Zookeeper with fixed format.
-
-        Args:
-            crawler_name (str): The crawler name.
-            is_group (bool): If it's True, generate node path for _group_ type meta-data.
-
-        Returns:
-            str: A Zookeeper node path.
-
-        """
-        if is_group:
-            return f"smoothcrawler/group/{crawler_name}"
-        else:
-            return f"smoothcrawler/node/{crawler_name}"
-
     def initial(self) -> None:
         """Initial processing of entire cluster running. This processing procedure like below:
 
@@ -375,11 +336,11 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
         """
         for _ in range(self._ensure_timeout):
             with self._zookeeper_client.restrict(
-                path=self.group_state_zookeeper_path,
+                path=self._zk_path.group_state_zookeeper_path,
                 restrict=ZookeeperRecipe.WRITE_LOCK,
                 identifier=self._state_identifier,
             ):
-                if not self._zookeeper_client.exist_node(path=self.group_state_zookeeper_path):
+                if not self._zookeeper_client.exist_node(path=self._zk_path.group_state_zookeeper_path):
                     state = Initial.group_state(
                         crawler_name=self._crawler_name,
                         total_crawler=self._runner + self._backup,
@@ -387,11 +348,11 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                         total_backup=self._backup,
                     )
                     self._metadata_util.set_metadata_to_zookeeper(
-                        path=self.group_state_zookeeper_path, metadata=state, create_node=True
+                        path=self._zk_path.group_state_zookeeper_path, metadata=state, create_node=True
                     )
                 else:
                     state = self._metadata_util.get_metadata_from_zookeeper(
-                        path=self.group_state_zookeeper_path, as_obj=GroupState
+                        path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
                     )
                     if not state.current_crawler or self._crawler_name not in state.current_crawler:
                         state = Update.group_state(
@@ -403,14 +364,14 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                             standby_id=self._initial_standby_id,
                         )
                         self._metadata_util.set_metadata_to_zookeeper(
-                            path=self.group_state_zookeeper_path, metadata=state
+                            path=self._zk_path.group_state_zookeeper_path, metadata=state
                         )
 
             if not self._ensure_register:
                 break
 
             state = self._metadata_util.get_metadata_from_zookeeper(
-                path=self.group_state_zookeeper_path, as_obj=GroupState
+                path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
             )
             assert state, "The meta data *State* should NOT be None."
             if len(set(state.current_crawler)) == self._total_crawler and self._crawler_name in state.current_crawler:
@@ -430,9 +391,9 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
 
         """
         state = Initial.node_state(group=self._crawler_group)
-        create_node = not self._zookeeper_client.exist_node(path=self.node_state_zookeeper_path)
+        create_node = not self._zookeeper_client.exist_node(path=self._zk_path.node_state_zookeeper_path)
         self._metadata_util.set_metadata_to_zookeeper(
-            path=self.node_state_zookeeper_path, metadata=state, create_node=create_node
+            path=self._zk_path.node_state_zookeeper_path, metadata=state, create_node=create_node
         )
 
     def register_task(self) -> None:
@@ -443,9 +404,9 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
 
         """
         task = Initial.task()
-        create_node = not self._zookeeper_client.exist_node(path=self.task_zookeeper_path)
+        create_node = not self._zookeeper_client.exist_node(path=self._zk_path.task_zookeeper_path)
         self._metadata_util.set_metadata_to_zookeeper(
-            path=self.task_zookeeper_path, metadata=task, create_node=create_node
+            path=self._zk_path.task_zookeeper_path, metadata=task, create_node=create_node
         )
 
     def register_heartbeat(
@@ -480,9 +441,9 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             heart_rhythm_timeout=heart_rhythm_timeout,
             time_format=time_format,
         )
-        create_node = not self._zookeeper_client.exist_node(path=self.heartbeat_zookeeper_path)
+        create_node = not self._zookeeper_client.exist_node(path=self._zk_path.heartbeat_zookeeper_path)
         self._metadata_util.set_metadata_to_zookeeper(
-            path=self.heartbeat_zookeeper_path, metadata=heartbeat, create_node=create_node
+            path=self._zk_path.heartbeat_zookeeper_path, metadata=heartbeat, create_node=create_node
         )
 
     def stop_update_heartbeat(self) -> None:
@@ -559,7 +520,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
         start = time.time()
         while True:
             state = self._metadata_util.get_metadata_from_zookeeper(
-                path=self.group_state_zookeeper_path, as_obj=GroupState
+                path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
             )
             if condition_callback(state):
                 return True
@@ -575,7 +536,9 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             A **ElectionResult** type value.
 
         """
-        state = self._metadata_util.get_metadata_from_zookeeper(path=self.group_state_zookeeper_path, as_obj=GroupState)
+        state = self._metadata_util.get_metadata_from_zookeeper(
+            path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
+        )
         return self._election_strategy.elect(
             candidate=self._crawler_name, member=state.current_crawler, index_sep=self._index_sep, spot=self._runner
         )
@@ -671,7 +634,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             self.wait_for_task(wait_time=wait_task_time)
         elif role is CrawlerStateRole.BACKUP_RUNNER:
             group_state = self._metadata_util.get_metadata_from_zookeeper(
-                path=self.group_state_zookeeper_path, as_obj=GroupState
+                path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
             )
             if self._crawler_name.split(self._index_sep)[-1] == group_state.standby_id:
                 self.wait_and_standby(wait_time=standby_wait_time, reset_timeout_threshold=reset_timeout_threshold)
@@ -709,7 +672,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
         #    }
         while True:
             task = self._metadata_util.get_metadata_from_zookeeper(
-                path=self.task_zookeeper_path, as_obj=Task, must_has_data=False
+                path=self._zk_path.task_zookeeper_path, as_obj=Task, must_has_data=False
             )
             if task.running_content:
                 # Start to run tasks ...
@@ -748,7 +711,8 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
 
         def _one_current_runner_is_dead(runner_name: str) -> Optional[str]:
             current_runner_heartbeat = self._metadata_util.get_metadata_from_zookeeper(
-                path=f"{self._generate_path(runner_name)}/{self._zookeeper_heartbeat_node_path}", as_obj=Heartbeat
+                path=f"{self._zk_path.generate_path(runner_name)}/{self._zookeeper_heartbeat_node_path}",
+                as_obj=Heartbeat,
             )
 
             heart_rhythm_time = current_runner_heartbeat.heart_rhythm_time
@@ -771,7 +735,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
 
         while True:
             group_state = self._metadata_util.get_metadata_from_zookeeper(
-                path=self.group_state_zookeeper_path, as_obj=GroupState
+                path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
             )
             chk_current_runners_is_dead = map(_one_current_runner_is_dead, group_state.current_runner)
             dead_current_runner_iter = filter(
@@ -782,7 +746,8 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                 # Only handle the first one of dead crawlers (if it has multiple dead crawlers
                 runner_name = dead_current_runner[0]
                 heartbeat = self._metadata_util.get_metadata_from_zookeeper(
-                    path=f"{self._generate_path(runner_name)}/{self._zookeeper_heartbeat_node_path}", as_obj=Heartbeat
+                    path=f"{self._zk_path.generate_path(runner_name)}/{self._zookeeper_heartbeat_node_path}",
+                    as_obj=Heartbeat,
                 )
                 task_of_dead_crawler = self.discover(dead_crawler_name=runner_name, heartbeat=heartbeat)
                 self.activate(dead_crawler_name=runner_name)
@@ -804,7 +769,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
         """
         while True:
             group_state = self._metadata_util.get_metadata_from_zookeeper(
-                path=self.group_state_zookeeper_path, as_obj=GroupState
+                path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
             )
             if self._crawler_name.split(self._index_sep)[-1] == group_state.standby_id:
                 # Start to do wait_and_standby
@@ -835,14 +800,16 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             content = TaskContentDataUtils.convert_to_running_content(content)
 
             # Update the ongoing task ID
-            original_task = self._metadata_util.get_metadata_from_zookeeper(path=self.task_zookeeper_path, as_obj=Task)
+            original_task = self._metadata_util.get_metadata_from_zookeeper(
+                path=self._zk_path.task_zookeeper_path, as_obj=Task
+            )
             if index == 0:
                 current_task = Update.task(
                     task=original_task, in_progressing_id=content.task_id, running_status=TaskResult.PROCESSING
                 )
             else:
                 current_task = Update.task(task=original_task, in_progressing_id=content.task_id)
-            self._metadata_util.set_metadata_to_zookeeper(path=self.task_zookeeper_path, metadata=current_task)
+            self._metadata_util.set_metadata_to_zookeeper(path=self._zk_path.task_zookeeper_path, metadata=current_task)
 
             # Run the task and update the meta data Task
             data = None
@@ -895,13 +862,13 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                 running_result=updated_running_result,
                 result_detail=result_detail,
             )
-            self._metadata_util.set_metadata_to_zookeeper(path=self.task_zookeeper_path, metadata=current_task)
+            self._metadata_util.set_metadata_to_zookeeper(path=self._zk_path.task_zookeeper_path, metadata=current_task)
 
         # Finish all tasks, record the running result and reset the content ...
         current_task = Update.task(
             task=current_task, running_content=[], in_progressing_id="-1", running_status=TaskResult.DONE
         )
-        self._metadata_util.set_metadata_to_zookeeper(path=self.task_zookeeper_path, metadata=current_task)
+        self._metadata_util.set_metadata_to_zookeeper(path=self._zk_path.task_zookeeper_path, metadata=current_task)
 
     def processing_crawling_task(self, content: RunningContent) -> Any:
         """The core of web spider implementation. All running functions it used are developers are familiar with ---
@@ -933,18 +900,19 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             Task: Meta-data **Task** from dead crawler instance.
 
         """
-        node_state_path = f"{self._generate_path(dead_crawler_name)}/{self._zookeeper_node_state_node_path}"
+        node_state_path = f"{self._zk_path.generate_path(dead_crawler_name)}/{self._zookeeper_node_state_node_path}"
         node_state = self._metadata_util.get_metadata_from_zookeeper(path=node_state_path, as_obj=NodeState)
         node_state.role = CrawlerStateRole.DEAD_RUNNER
         self._metadata_util.set_metadata_to_zookeeper(path=node_state_path, metadata=node_state)
 
         task = self._metadata_util.get_metadata_from_zookeeper(
-            path=f"{self._generate_path(dead_crawler_name)}/{self._zookeeper_task_node_path}", as_obj=Task
+            path=f"{self._zk_path.generate_path(dead_crawler_name)}/{self._zookeeper_task_node_path}", as_obj=Task
         )
         heartbeat.healthy_state = HeartState.ASYSTOLE
         heartbeat.task_state = task.running_status
         self._metadata_util.set_metadata_to_zookeeper(
-            path=f"{self._generate_path(dead_crawler_name)}/{self._zookeeper_heartbeat_node_path}", metadata=heartbeat
+            path=f"{self._zk_path.generate_path(dead_crawler_name)}/{self._zookeeper_heartbeat_node_path}",
+            metadata=heartbeat,
         )
 
         return task
@@ -961,17 +929,19 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
 
         """
         node_state = self._metadata_util.get_metadata_from_zookeeper(
-            path=self.node_state_zookeeper_path, as_obj=NodeState
+            path=self._zk_path.node_state_zookeeper_path, as_obj=NodeState
         )
         self._crawler_role = CrawlerStateRole.RUNNER
         node_state.role = self._crawler_role
-        self._metadata_util.set_metadata_to_zookeeper(path=self.node_state_zookeeper_path, metadata=node_state)
+        self._metadata_util.set_metadata_to_zookeeper(path=self._zk_path.node_state_zookeeper_path, metadata=node_state)
 
         with self._zookeeper_client.restrict(
-            path=self.group_state_zookeeper_path, restrict=ZookeeperRecipe.WRITE_LOCK, identifier=self._state_identifier
+            path=self._zk_path.group_state_zookeeper_path,
+            restrict=ZookeeperRecipe.WRITE_LOCK,
+            identifier=self._state_identifier,
         ):
             state = self._metadata_util.get_metadata_from_zookeeper(
-                path=self.group_state_zookeeper_path, as_obj=GroupState
+                path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
             )
 
             state.total_backup = state.total_backup - 1
@@ -983,7 +953,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             state.fail_runner.append(dead_crawler_name)
             state.standby_id = str(int(state.standby_id) + 1)
 
-            self._metadata_util.set_metadata_to_zookeeper(path=self.group_state_zookeeper_path, metadata=state)
+            self._metadata_util.set_metadata_to_zookeeper(path=self._zk_path.group_state_zookeeper_path, metadata=state)
 
     def hand_over_task(self, task: Task) -> None:
         """Hand over the task of the dead crawler instance. It would get the meta-data **Task** from dead crawler and
@@ -998,7 +968,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
         """
         if task.running_status == TaskResult.PROCESSING.value:
             # Run the tasks from the start index
-            self._metadata_util.set_metadata_to_zookeeper(path=self.task_zookeeper_path, metadata=task)
+            self._metadata_util.set_metadata_to_zookeeper(path=self._zk_path.task_zookeeper_path, metadata=task)
         elif task.running_status in [TaskResult.NOTHING.value, TaskResult.ERROR.value]:
             # Reset some specific attributes
             updated_task = Update.task(
@@ -1008,7 +978,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                 result_detail=[],
             )
             # Reruns all tasks
-            self._metadata_util.set_metadata_to_zookeeper(path=self.task_zookeeper_path, metadata=updated_task)
+            self._metadata_util.set_metadata_to_zookeeper(path=self._zk_path.task_zookeeper_path, metadata=updated_task)
         else:
             # Ignore and don't do anything if the task state is nothing or done.
             pass
@@ -1024,16 +994,20 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
 
         """
         node_state = self._metadata_util.get_metadata_from_zookeeper(
-            path=self.node_state_zookeeper_path, as_obj=NodeState
+            path=self._zk_path.node_state_zookeeper_path, as_obj=NodeState
         )
         updated_node_state = Update.node_state(node_state=node_state, role=role)
-        self._metadata_util.set_metadata_to_zookeeper(path=self.node_state_zookeeper_path, metadata=updated_node_state)
+        self._metadata_util.set_metadata_to_zookeeper(
+            path=self._zk_path.node_state_zookeeper_path, metadata=updated_node_state
+        )
 
         with self._zookeeper_client.restrict(
-            path=self.group_state_zookeeper_path, restrict=ZookeeperRecipe.WRITE_LOCK, identifier=self._state_identifier
+            path=self._zk_path.group_state_zookeeper_path,
+            restrict=ZookeeperRecipe.WRITE_LOCK,
+            identifier=self._state_identifier,
         ):
             state = self._metadata_util.get_metadata_from_zookeeper(
-                path=self.group_state_zookeeper_path, as_obj=GroupState
+                path=self._zk_path.group_state_zookeeper_path, as_obj=GroupState
             )
             if role is CrawlerStateRole.RUNNER:
                 updated_state = Update.group_state(state, append_current_runner=[self._crawler_name])
@@ -1051,7 +1025,9 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             else:
                 raise ValueError(f"It doesn't support {role} recently.")
 
-            self._metadata_util.set_metadata_to_zookeeper(path=self.group_state_zookeeper_path, metadata=updated_state)
+            self._metadata_util.set_metadata_to_zookeeper(
+                path=self._zk_path.group_state_zookeeper_path, metadata=updated_state
+            )
 
     def _run_updating_heartbeat_thread(self) -> None:
         """Activate and run a new thread to keep updating **Heartbeat** info.
@@ -1078,9 +1054,11 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
             if not self._updating_stop_signal:
                 try:
                     # Get *Task* and *Heartbeat* info
-                    task = self._metadata_util.get_metadata_from_zookeeper(path=self.task_zookeeper_path, as_obj=Task)
+                    task = self._metadata_util.get_metadata_from_zookeeper(
+                        path=self._zk_path.task_zookeeper_path, as_obj=Task
+                    )
                     heartbeat = self._metadata_util.get_metadata_from_zookeeper(
-                        path=self.heartbeat_zookeeper_path, as_obj=Heartbeat
+                        path=self._zk_path.heartbeat_zookeeper_path, as_obj=Heartbeat
                     )
 
                     # Update the values
@@ -1091,7 +1069,7 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                         task_state=task.running_status,
                     )
                     self._metadata_util.set_metadata_to_zookeeper(
-                        path=self.heartbeat_zookeeper_path, metadata=heartbeat
+                        path=self._zk_path.heartbeat_zookeeper_path, metadata=heartbeat
                     )
 
                     # Sleep ...
@@ -1100,9 +1078,11 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                     self._updating_exception = e
                     break
             else:
-                task = self._metadata_util.get_metadata_from_zookeeper(path=self.task_zookeeper_path, as_obj=Task)
+                task = self._metadata_util.get_metadata_from_zookeeper(
+                    path=self._zk_path.task_zookeeper_path, as_obj=Task
+                )
                 heartbeat = self._metadata_util.get_metadata_from_zookeeper(
-                    path=self.heartbeat_zookeeper_path, as_obj=Heartbeat
+                    path=self._zk_path.heartbeat_zookeeper_path, as_obj=Heartbeat
                 )
                 heartbeat = Update.heartbeat(
                     heartbeat,
@@ -1110,7 +1090,9 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
                     healthy_state=HeartState.APPARENT_DEATH,
                     task_state=task.running_status,
                 )
-                self._metadata_util.set_metadata_to_zookeeper(path=self.heartbeat_zookeeper_path, metadata=heartbeat)
+                self._metadata_util.set_metadata_to_zookeeper(
+                    path=self._zk_path.heartbeat_zookeeper_path, metadata=heartbeat
+                )
                 break
         if self._updating_exception:
             raise self._updating_exception

--- a/test/integration_test/_test_utils/_instance_value.py
+++ b/test/integration_test/_test_utils/_instance_value.py
@@ -52,25 +52,25 @@ class _TestValue:
     @property
     def group_state_zookeeper_path(self) -> str:
         if self._group_state_zk_path == "":
-            self._group_state_zk_path = self._zk_path.group_state_zookeeper_path
+            self._group_state_zk_path = self._zk_path.group_state
         return self._group_state_zk_path
 
     @property
     def node_state_zookeeper_path(self) -> str:
         if self._node_state_zk_path == "":
-            self._node_state_zk_path = self._zk_path.node_state_zookeeper_path
+            self._node_state_zk_path = self._zk_path.node_state
         return self._node_state_zk_path
 
     @property
     def task_zookeeper_path(self) -> str:
         if self._task_zk_path == "":
-            self._task_zk_path = self._zk_path.task_zookeeper_path
+            self._task_zk_path = self._zk_path.task
         return self._task_zk_path
 
     @property
     def heartbeat_zookeeper_path(self) -> str:
         if self._heartbeat_zk_path == "":
-            self._heartbeat_zk_path = self._zk_path.heartbeat_zookeeper_path
+            self._heartbeat_zk_path = self._zk_path.heartbeat
         return self._heartbeat_zk_path
 
     @property

--- a/test/integration_test/_test_utils/_instance_value.py
+++ b/test/integration_test/_test_utils/_instance_value.py
@@ -1,12 +1,12 @@
 import json
 from typing import List
 
-from smoothcrawler_cluster.crawler import ZookeeperCrawler
+from smoothcrawler_cluster._utils.zookeeper import ZookeeperPath
 from smoothcrawler_cluster.model import GroupState, Heartbeat, NodeState, Task
 
 from ..._values import (
-    _Backup_Crawler_Value,
-    _Runner_Crawler_Value,
+    _Crawler_Group_Name_Value,
+    _Crawler_Name_Value,
     setup_group_state,
     setup_heartbeat,
     setup_node_state,
@@ -39,40 +39,38 @@ class _TestValue:
         return cls._test_value_instance
 
     def __init__(self):
-        self._zk_client_inst = ZookeeperCrawler(
-            runner=_Runner_Crawler_Value, backup=_Backup_Crawler_Value, initial=False
-        )
+        self._zk_path = ZookeeperPath(name=_Crawler_Name_Value, group=_Crawler_Group_Name_Value)
 
     @property
     def name(self):
-        return self._zk_client_inst.name
+        return _Crawler_Name_Value
 
     @property
     def group(self):
-        return self._zk_client_inst.group
+        return _Crawler_Group_Name_Value
 
     @property
     def group_state_zookeeper_path(self) -> str:
         if self._group_state_zk_path == "":
-            self._group_state_zk_path = self._zk_client_inst.group_state_zookeeper_path
+            self._group_state_zk_path = self._zk_path.group_state_zookeeper_path
         return self._group_state_zk_path
 
     @property
     def node_state_zookeeper_path(self) -> str:
         if self._node_state_zk_path == "":
-            self._node_state_zk_path = self._zk_client_inst.node_state_zookeeper_path
+            self._node_state_zk_path = self._zk_path.node_state_zookeeper_path
         return self._node_state_zk_path
 
     @property
     def task_zookeeper_path(self) -> str:
         if self._task_zk_path == "":
-            self._task_zk_path = self._zk_client_inst.task_zookeeper_path
+            self._task_zk_path = self._zk_path.task_zookeeper_path
         return self._task_zk_path
 
     @property
     def heartbeat_zookeeper_path(self) -> str:
         if self._heartbeat_zk_path == "":
-            self._heartbeat_zk_path = self._zk_client_inst.heartbeat_zookeeper_path
+            self._heartbeat_zk_path = self._zk_path.heartbeat_zookeeper_path
         return self._heartbeat_zk_path
 
     @property

--- a/test/integration_test/_test_utils/_zk_testsuite.py
+++ b/test/integration_test/_test_utils/_zk_testsuite.py
@@ -133,11 +133,12 @@ class ZK:
 
     @classmethod
     def _initial_zk_opt_inst(cls, uit_object):
-        if not isinstance(uit_object, ZookeeperCrawler):
-            inst = _TestValue()
-        else:
-            inst = uit_object
-        return inst
+        # if not isinstance(uit_object, ZookeeperCrawler):
+        #     inst = _TestValue()
+        # else:
+        #     inst = uit_object
+        # return inst
+        return _TestValue()
 
     @classmethod
     def _paths_to_list(cls, path: Union[ZKNode, List[ZKNode]]) -> List[ZKNode]:

--- a/test/integration_test/crawler.py
+++ b/test/integration_test/crawler.py
@@ -70,7 +70,7 @@ class TestZookeeperCrawlerSingleInstance(ZKTestSpec):
     def test__update_crawler_role(self, uit_object: ZookeeperCrawler):
         # Checking initial state
         group_state = uit_object._metadata_util.get_metadata_from_zookeeper(
-            path=uit_object._zk_path.group_state_zookeeper_path, as_obj=GroupState
+            path=uit_object._zk_path.group_state, as_obj=GroupState
         )
         assert (
             len(group_state.current_crawler) == 0
@@ -83,7 +83,7 @@ class TestZookeeperCrawlerSingleInstance(ZKTestSpec):
         ), "At initial process, the length of current backup list should be 0."
 
         node_state = uit_object._metadata_util.get_metadata_from_zookeeper(
-            path=uit_object._zk_path.node_state_zookeeper_path, as_obj=NodeState
+            path=uit_object._zk_path.node_state, as_obj=NodeState
         )
         assert node_state.role == CrawlerStateRole.INITIAL.value, (
             "At initial process, the role of crawler instance should be *initial* (or value of "
@@ -95,7 +95,7 @@ class TestZookeeperCrawlerSingleInstance(ZKTestSpec):
 
         # Verify the updated state
         updated_group_state = uit_object._metadata_util.get_metadata_from_zookeeper(
-            path=uit_object._zk_path.group_state_zookeeper_path, as_obj=GroupState
+            path=uit_object._zk_path.group_state, as_obj=GroupState
         )
         assert (
             len(updated_group_state.current_runner) == 1
@@ -105,7 +105,7 @@ class TestZookeeperCrawlerSingleInstance(ZKTestSpec):
         ), "After update the *state* meta data, the length of current crawler list should be 0 because it's *runner*."
 
         updated_node_state = uit_object._metadata_util.get_metadata_from_zookeeper(
-            path=uit_object._zk_path.node_state_zookeeper_path, as_obj=NodeState
+            path=uit_object._zk_path.node_state, as_obj=NodeState
         )
         assert (
             updated_node_state.role == CrawlerStateRole.RUNNER.value
@@ -750,10 +750,10 @@ class TestZookeeperCrawlerFeatureWithMultipleCrawlers(MultiCrawlerTestSuite):
             current_runner=["sc-crawler_0"],
             current_backup=["sc-crawler_1", "sc-crawler_2"],
         )
-        if self._exist_node(path=zk_crawler._zk_path.group_state_zookeeper_path) is None:
+        if self._exist_node(path=zk_crawler._zk_path.group_state) is None:
             state_data_str = json.dumps(state.to_readable_object())
             self._create_node(
-                path=zk_crawler._zk_path.group_state_zookeeper_path,
+                path=zk_crawler._zk_path.group_state,
                 value=bytes(state_data_str, "utf-8"),
                 include_data=True,
             )
@@ -767,7 +767,7 @@ class TestZookeeperCrawlerFeatureWithMultipleCrawlers(MultiCrawlerTestSuite):
                 time.sleep(5)
                 state.standby_id = "2"
                 zk_crawler._metadata_util.set_metadata_to_zookeeper(
-                    path=zk_crawler._zk_path.group_state_zookeeper_path, metadata=state
+                    path=zk_crawler._zk_path.group_state, metadata=state
                 )
             except Exception as e:
                 running_flag["_update_state_standby_id"] = False
@@ -790,8 +790,8 @@ class TestZookeeperCrawlerFeatureWithMultipleCrawlers(MultiCrawlerTestSuite):
                 running_flag["_run_target_test_func"] = True
                 running_exception["_run_target_test_func"] = None
             finally:
-                if self._exist_node(path=zk_crawler._zk_path.group_state_zookeeper_path):
-                    self._delete_node(path=zk_crawler._zk_path.group_state_zookeeper_path)
+                if self._exist_node(path=zk_crawler._zk_path.group_state):
+                    self._delete_node(path=zk_crawler._zk_path.group_state)
 
         run_2_diff_workers(
             func1_ps=(_update_state_standby_id, (), False), func2_ps=(_run_target_test_func, (), False), worker="thread"

--- a/test/unit_test/_utils/zookeeper.py
+++ b/test/unit_test/_utils/zookeeper.py
@@ -44,6 +44,17 @@ class TestZookeeperPath:
         # Verify values
         ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/heartbeat")
 
+    @pytest.mark.parametrize("is_group", [True, False])
+    def test_generate_parent_node(self, zk_path: ZookeeperPath, is_group: bool):
+        # Get value by target method for testing
+        path = zk_path.generate_parent_node(crawler_name=_Crawler_Name_Value, is_group=is_group)
+
+        # Verify values
+        if is_group:
+            ValueFormatAssertion(target=path, regex=r"smoothcrawler/group/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}")
+        else:
+            ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}")
+
 
 class TestZookeeperNode:
     @pytest.fixture(scope="function")

--- a/test/unit_test/_utils/zookeeper.py
+++ b/test/unit_test/_utils/zookeeper.py
@@ -1,11 +1,51 @@
 import pytest
 
-from smoothcrawler_cluster._utils.zookeeper import ZookeeperNode
+from smoothcrawler_cluster._utils.zookeeper import ZookeeperNode, ZookeeperPath
 
-from ..._values import Test_Zookeeper_Path, Test_Zookeeper_String_Value
+from ..._assertion import ValueFormatAssertion
+from ..._values import (
+    Test_Zookeeper_Path,
+    Test_Zookeeper_String_Value,
+    _Crawler_Group_Name_Value,
+    _Crawler_Name_Value,
+)
 
 
 class TestZookeeperPath:
+    @pytest.fixture(scope="function")
+    def zk_path(self) -> ZookeeperPath:
+        return ZookeeperPath(name=_Crawler_Name_Value, group=_Crawler_Group_Name_Value)
+
+    def test_property_group_state_zookeeper_path(self, zk_path: ZookeeperPath):
+        # Get value by target method for testing
+        path = zk_path.group_state_zookeeper_path
+
+        # Verify values
+        ValueFormatAssertion(target=path, regex=r"smoothcrawler/group/[\w\-_]{1,64}/state")
+
+    def test_property_node_state_zookeeper_path(self, zk_path: ZookeeperPath):
+        # Get value by target method for testing
+        path = zk_path.node_state_zookeeper_path
+
+        # Verify values
+        ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/state")
+
+    def test_property_task_zookeeper_path(self, zk_path: ZookeeperPath):
+        # Get value by target method for testing
+        path = zk_path.task_zookeeper_path
+
+        # Verify values
+        ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/task")
+
+    def test_property_heartbeat_zookeeper_path(self, zk_path: ZookeeperPath):
+        # Get value by target method for testing
+        path = zk_path.heartbeat_zookeeper_path
+
+        # Verify values
+        ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/heartbeat")
+
+
+class TestZookeeperNode:
     @pytest.fixture(scope="function")
     def zk_path(self) -> ZookeeperNode:
         return ZookeeperNode()

--- a/test/unit_test/_utils/zookeeper.py
+++ b/test/unit_test/_utils/zookeeper.py
@@ -18,28 +18,28 @@ class TestZookeeperPath:
 
     def test_property_group_state_zookeeper_path(self, zk_path: ZookeeperPath):
         # Get value by target method for testing
-        path = zk_path.group_state_zookeeper_path
+        path = zk_path.group_state
 
         # Verify values
         ValueFormatAssertion(target=path, regex=r"smoothcrawler/group/[\w\-_]{1,64}/state")
 
     def test_property_node_state_zookeeper_path(self, zk_path: ZookeeperPath):
         # Get value by target method for testing
-        path = zk_path.node_state_zookeeper_path
+        path = zk_path.node_state
 
         # Verify values
         ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/state")
 
     def test_property_task_zookeeper_path(self, zk_path: ZookeeperPath):
         # Get value by target method for testing
-        path = zk_path.task_zookeeper_path
+        path = zk_path.task
 
         # Verify values
         ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/task")
 
     def test_property_heartbeat_zookeeper_path(self, zk_path: ZookeeperPath):
         # Get value by target method for testing
-        path = zk_path.heartbeat_zookeeper_path
+        path = zk_path.heartbeat
 
         # Verify values
         ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/heartbeat")

--- a/test/unit_test/_utils/zookeeper.py
+++ b/test/unit_test/_utils/zookeeper.py
@@ -16,28 +16,28 @@ class TestZookeeperPath:
     def zk_path(self) -> ZookeeperPath:
         return ZookeeperPath(name=_Crawler_Name_Value, group=_Crawler_Group_Name_Value)
 
-    def test_property_group_state_zookeeper_path(self, zk_path: ZookeeperPath):
+    def test_property_group_state(self, zk_path: ZookeeperPath):
         # Get value by target method for testing
         path = zk_path.group_state
 
         # Verify values
         ValueFormatAssertion(target=path, regex=r"smoothcrawler/group/[\w\-_]{1,64}/state")
 
-    def test_property_node_state_zookeeper_path(self, zk_path: ZookeeperPath):
+    def test_property_node_state(self, zk_path: ZookeeperPath):
         # Get value by target method for testing
         path = zk_path.node_state
 
         # Verify values
         ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/state")
 
-    def test_property_task_zookeeper_path(self, zk_path: ZookeeperPath):
+    def test_property_task(self, zk_path: ZookeeperPath):
         # Get value by target method for testing
         path = zk_path.task
 
         # Verify values
         ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/task")
 
-    def test_property_heartbeat_zookeeper_path(self, zk_path: ZookeeperPath):
+    def test_property_heartbeat(self, zk_path: ZookeeperPath):
         # Get value by target method for testing
         path = zk_path.heartbeat
 

--- a/test/unit_test/crawler.py
+++ b/test/unit_test/crawler.py
@@ -44,34 +44,6 @@ class TestZookeeperCrawler:
             target=zookeeper_hosts, regex="(localhost|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}):[0-9]{1,6}"
         )
 
-    def test_property_group_state_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
-        # Get value by target method for testing
-        path = zk_crawler.group_state_zookeeper_path
-
-        # Verify values
-        ValueFormatAssertion(target=path, regex=r"smoothcrawler/group/[\w\-_]{1,64}/state")
-
-    def test_property_node_state_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
-        # Get value by target method for testing
-        path = zk_crawler.node_state_zookeeper_path
-
-        # Verify values
-        ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/state")
-
-    def test_property_task_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
-        # Get value by target method for testing
-        path = zk_crawler.task_zookeeper_path
-
-        # Verify values
-        ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/task")
-
-    def test_property_heartbeat_zookeeper_path(self, zk_crawler: ZookeeperCrawler):
-        # Get value by target method for testing
-        path = zk_crawler.heartbeat_zookeeper_path
-
-        # Verify values
-        ValueFormatAssertion(target=path, regex=r"smoothcrawler/node/[\w\-_]{1,64}[-_]{1}[0-9]{1,10000}/heartbeat")
-
     def test_property_ensure_register(self, zk_crawler: ZookeeperCrawler):
         # Test getter
         ensure_register = zk_crawler.ensure_register


### PR DESCRIPTION
### _Target_

* Move the properties about Zookeeper node paths to another new object.


### _Modify Code Scope_

* Source Code
    * module _/_utils.zookeeper_.
    * module _crawler_.

* Testing Code
    * Unit Test & Integration Test
        * Testing module about _crawler_ and _zookeeper_.

* Documentation
    * Section **API References / Inner Modules / Utils Module - Zookeeper**.


### _Effecting Scope_

* Nothing, this PR's responsible of refactoring the Zookeeper path attributes to another new object.


### _Description_

* Refactor the source code about moving the properties about Zookeeper path to another new object.
    * crawler.ZookeeperCrawler.group_state_zookeeper_path   --->   ._utils.zookeeper.ZookeeperPath.group_state
    * crawler.ZookeeperCrawler.node_state_zookeeper_path   --->   ._utils.zookeeper.ZookeeperPath.node_state
    * crawler.ZookeeperCrawler.task_zookeeper_path   --->   ._utils.zookeeper.ZookeeperPath.task
    * crawler.ZookeeperCrawler.heartbeat_zookeeper_path   --->   ._utils.zookeeper.ZookeeperPath.heartbeat

* Refactor the testing code which is related the Zookeeper path.
* Add new section in **API References**.
