### PR TITLE
🛠🐛💣 [Bug Fix] (config) Specifying the *Zookeeper* Docker image version to '3.8.0'. 

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: smoothcrawler-cluster ci/cd
+name: ci/cd
 
 on:
   push:

--- a/.github/workflows/run_test_items_via_pytest_with_msg_queue_sys.yaml
+++ b/.github/workflows/run_test_items_via_pytest_with_msg_queue_sys.yaml
@@ -81,7 +81,7 @@ jobs:
     services:
       # Zookeeper is necessary for Kafka.
       pytest_zookeeper:
-        image: zookeeper:latest
+        image: zookeeper:3.8.0
         env:
           ZOO_MAX_CLIENT_CNXNS: 1000
         ports:


### PR DESCRIPTION
### _Target_

* Rename the CI/CD process.
* Specifying the **Zookeeper** Docker image version to _3.8.0_. 


### _Modify Code Scope_

* Configuration
    * The **GitHub Action** configuration.


### _Effecting Scope_

* The Docket image version which would be downloaded in integration test.


### _Description_

* Rename the CI/CD process.
* Specifying the **Zookeeper** Docker image version to be _3.8.0_ to fix issue occur in CI/CD process.
    * **Zookeeper** Docker hub: https://hub.docker.com/_/zookeeper/tags?page=1&name=3.8
