### PR TITLE
🔬🧪🧬 [Refactor] (code + test) Refactor to use data objects *CrawlerName* and *MetaDataOpt* to let arguments passing to be more simple and clear.

### DIFF
--- a/smoothcrawler_cluster/crawler/crawlers.py
+++ b/smoothcrawler_cluster/crawler/crawlers.py
@@ -322,14 +322,10 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
         """:obj:`Register`: Properties with both a getter and setter. The getter and setter of option *ensure_wait*."""
         if not self._register:
             self._register = Register(
-                crawler_name=self._crawler_name,
-                crawler_group=self._crawler_group,
-                index_sep=self._index_sep,
+                name=self._crawler_name_data,
                 path=self._zk_path,
-                get_metadata=self._get_metadata,
-                set_metadata=self._set_metadata,
-                exist_metadata=self._exist_metadata,
-                opt_metadata_with_lock=self.distributed_lock_adapter,
+                metadata_opts_callback=self._metadata_opts_callback,
+                lock=self.distributed_lock_adapter,
             )
         return self._register
 

--- a/smoothcrawler_cluster/crawler/crawlers.py
+++ b/smoothcrawler_cluster/crawler/crawlers.py
@@ -25,7 +25,13 @@ from ..model import (
     RunningContent,
     Update,
 )
-from ..model._data import CrawlerTimer, TimeInterval, TimerThreshold
+from ..model._data import (
+    CrawlerName,
+    CrawlerTimer,
+    MetaDataOpt,
+    TimeInterval,
+    TimerThreshold,
+)
 from ..model.metadata import _BaseMetaData
 from ..register import Register
 from .adapter import DistributedLock
@@ -230,14 +236,22 @@ class ZookeeperCrawler(BaseDecentralizedCrawler, BaseCrawler):
         self._heartbeat_update_timeout = heartbeat_update_timeout
         self._heartbeat_dead_threshold = heartbeat_dead_threshold
 
+        self._crawler_name_data = CrawlerName()
+        self._crawler_name_data.group = self._crawler_group
+        self._crawler_name_data.base_name = self._crawler_name.split(self._index_sep)[0]
+        self._crawler_name_data.index_separation = self._index_sep
+        self._crawler_name_data.id = self._crawler_name.split(self._index_sep)[-1]
+
+        self._metadata_opts_callback = MetaDataOpt()
+        self._metadata_opts_callback.exist_callback = self._exist_metadata
+        self._metadata_opts_callback.get_callback = self._get_metadata
+        self._metadata_opts_callback.set_callback = self._set_metadata
+
         self._workflow_dispatcher = WorkflowDispatcher(
-            crawler_name=self._crawler_name,
-            group=self._crawler_group,
-            index_sep=self._index_sep,
+            name=self._crawler_name_data,
             path=self._zk_path,
-            get_metadata_callback=self._get_metadata,
-            set_metadata_callback=self._set_metadata,
-            opt_metadata_with_lock=self.distributed_lock_adapter,
+            metadata_opts_callback=self._metadata_opts_callback,
+            lock=self.distributed_lock_adapter,
             crawler_process_callback=self._run_crawling_processing,
         )
         self._heartbeat_workflow = self._workflow_dispatcher.heartbeat()

--- a/smoothcrawler_cluster/crawler/dispatcher.py
+++ b/smoothcrawler_cluster/crawler/dispatcher.py
@@ -44,7 +44,7 @@ class WorkflowDispatcher:
         name: CrawlerName,
         path: MetaDataPath,
         metadata_opts_callback: MetaDataOpt,
-        opt_metadata_with_lock: DistributedLock,
+        lock: DistributedLock,
         crawler_process_callback: Callable,
     ):
         """
@@ -55,14 +55,14 @@ class WorkflowDispatcher:
             path (Type[MetaDataPath]): The objects which has all meta-data object's path property.
             metadata_opts_callback (MetaDataOpt): The data object *MetaDataOpt* which provides multiple callback
                 functions about getting and setting meta-data.
-            opt_metadata_with_lock (DistributedLock): The adapter of distributed lock.
+            lock (DistributedLock): The adapter of distributed lock.
             crawler_process_callback (Callable): The callback function about running the crawler core processes.
         """
         self._crawler_name = name
         self._path = path
         self._metadata_opts_callback = metadata_opts_callback
         self._get_metadata = self._metadata_opts_callback.get_callback
-        self._opt_metadata_with_lock = opt_metadata_with_lock
+        self._lock = lock
         self._crawler_process_callback = crawler_process_callback
 
     def dispatch(self, role: Union[str, CrawlerStateRole]) -> Optional[BaseRoleWorkflow]:
@@ -94,7 +94,7 @@ class WorkflowDispatcher:
             "name": self._crawler_name,
             "path": self._path,
             "metadata_opts_callback": self._metadata_opts_callback,
-            "opt_metadata_with_lock": self._opt_metadata_with_lock,
+            "lock": self._lock,
             "crawler_process_callback": self._crawler_process_callback,
         }
         if self._is(role, CrawlerStateRole.RUNNER):

--- a/smoothcrawler_cluster/crawler/dispatcher.py
+++ b/smoothcrawler_cluster/crawler/dispatcher.py
@@ -58,7 +58,7 @@ class WorkflowDispatcher:
             lock (DistributedLock): The adapter of distributed lock.
             crawler_process_callback (Callable): The callback function about running the crawler core processes.
         """
-        self._crawler_name = name
+        self._crawler_name_data = name
         self._path = path
         self._metadata_opts_callback = metadata_opts_callback
         self._get_metadata = self._metadata_opts_callback.get_callback
@@ -91,7 +91,7 @@ class WorkflowDispatcher:
 
         """
         role_workflow_args = {
-            "name": self._crawler_name,
+            "name": self._crawler_name_data,
             "path": self._path,
             "metadata_opts_callback": self._metadata_opts_callback,
             "lock": self._lock,
@@ -106,7 +106,7 @@ class WorkflowDispatcher:
                 return SecondaryBackupRunnerWorkflow(**role_workflow_args)
         else:
             if self._is(role, CrawlerStateRole.DEAD_RUNNER) or self._is(role, CrawlerStateRole.DEAD_BACKUP_RUNNER):
-                raise CrawlerIsDeadError(crawler_name=str(self._crawler_name), group=self._crawler_name.group)
+                raise CrawlerIsDeadError(crawler_name=str(self._crawler_name_data), group=self._crawler_name_data.group)
             else:
                 raise NotImplementedError(f"It doesn't support crawler role {role} in *SmoothCrawler-Cluster*.")
 
@@ -118,7 +118,7 @@ class WorkflowDispatcher:
 
         """
         workflow_args = {
-            "name": self._crawler_name,
+            "name": self._crawler_name_data,
             "path": self._path,
             "metadata_opts_callback": self._metadata_opts_callback,
         }
@@ -149,4 +149,4 @@ class WorkflowDispatcher:
 
         """
         group_state = self._get_metadata(path=self._path.group_state, as_obj=GroupState)
-        return self._crawler_name.id == group_state.standby_id
+        return self._crawler_name_data.id == group_state.standby_id

--- a/smoothcrawler_cluster/crawler/workflow.py
+++ b/smoothcrawler_cluster/crawler/workflow.py
@@ -97,7 +97,7 @@ class BaseRoleWorkflow(BaseWorkflow):
         name: CrawlerName,
         path: Type[MetaDataPath],
         metadata_opts_callback: MetaDataOpt,
-        opt_metadata_with_lock: DistributedLock,
+        lock: DistributedLock,
         crawler_process_callback: Callable,
     ):
         """
@@ -108,7 +108,7 @@ class BaseRoleWorkflow(BaseWorkflow):
             path (Type[MetaDataPath]): The objects which has all meta-data object's path property.
             metadata_opts_callback (MetaDataOpt): The data object *MetaDataOpt* which provides multiple callback
                 functions about getting and setting meta-data.
-            opt_metadata_with_lock (DistributedLock): The adapter of distributed lock.
+            lock (DistributedLock): The adapter of distributed lock.
             crawler_process_callback (Callable): The callback function about running the crawler core processes.
         """
         super().__init__(
@@ -116,7 +116,7 @@ class BaseRoleWorkflow(BaseWorkflow):
             path=path,
             metadata_opts_callback=metadata_opts_callback,
         )
-        self._opt_metadata_with_lock = opt_metadata_with_lock
+        self._lock = lock
         self._crawler_process_callback = crawler_process_callback
 
     @property
@@ -436,7 +436,7 @@ class PrimaryBackupRunnerWorkflow(BaseRoleWorkflow):
         node_state.role = CrawlerStateRole.RUNNER
         self._set_metadata(path=self._path.node_state, metadata=node_state)
 
-        self._opt_metadata_with_lock.strongly_run(function=_update_group_state)
+        self._lock.strongly_run(function=_update_group_state)
 
     def hand_over_task(self, task: Task) -> None:
         """Hand over the task of the dead crawler instance. It would get the meta-data **Task** from dead crawler and

--- a/smoothcrawler_cluster/crawler/workflow.py
+++ b/smoothcrawler_cluster/crawler/workflow.py
@@ -50,22 +50,23 @@ class BaseWorkflow(metaclass=ABCMeta):
         self,
         name: CrawlerName,
         path: Type[MetaDataPath],
-        get_metadata: Callable,
-        set_metadata: Callable,
+        metadata_opts_callback: MetaDataOpt,
     ):
         """
 
         Args:
-            name (str): The data object **CrawlerName** which provides some attribute like crawler instance's name or
-                ID, etc.
+            name (CrawlerName): The data object **CrawlerName** which provides some attribute like crawler instance's
+                name or ID, etc.
             path (Type[MetaDataPath]): The objects which has all meta-data object's path property.
-            get_metadata (Callable): The callback function about getting meta-data as object.
-            set_metadata (Callable): The callback function about setting meta-data from object.
+            metadata_opts_callback (MetaDataOpt): The data object *MetaDataOpt* which provides multiple callback
+                functions about getting and setting meta-data.
         """
         self._crawler_name = name
         self._path = path
-        self._get_metadata = get_metadata
-        self._set_metadata = set_metadata
+        # get_metadata (Callable): The callback function about getting meta-data as object.
+        self._get_metadata = metadata_opts_callback.get_callback
+        # set_metadata (Callable): The callback function about setting meta-data from object.
+        self._set_metadata = metadata_opts_callback.set_callback
 
     @abstractmethod
     def run(self, *args, **kwargs) -> Any:
@@ -95,27 +96,25 @@ class BaseRoleWorkflow(BaseWorkflow):
         self,
         name: CrawlerName,
         path: Type[MetaDataPath],
-        get_metadata: Callable,
-        set_metadata: Callable,
+        metadata_opts_callback: MetaDataOpt,
         opt_metadata_with_lock: DistributedLock,
         crawler_process_callback: Callable,
     ):
         """
 
         Args:
-            name (str): The data object **CrawlerName** which provides some attribute like crawler instance's name or
-                ID, etc.
+            name (CrawlerName): The data object **CrawlerName** which provides some attribute like crawler instance's
+                name or ID, etc.
             path (Type[MetaDataPath]): The objects which has all meta-data object's path property.
-            get_metadata (Callable): The callback function about getting meta-data as object.
-            set_metadata (Callable): The callback function about setting meta-data from object.
+            metadata_opts_callback (MetaDataOpt): The data object *MetaDataOpt* which provides multiple callback
+                functions about getting and setting meta-data.
             opt_metadata_with_lock (DistributedLock): The adapter of distributed lock.
             crawler_process_callback (Callable): The callback function about running the crawler core processes.
         """
         super().__init__(
             name=name,
             path=path,
-            get_metadata=get_metadata,
-            set_metadata=set_metadata,
+            metadata_opts_callback=metadata_opts_callback,
         )
         self._opt_metadata_with_lock = opt_metadata_with_lock
         self._crawler_process_callback = crawler_process_callback

--- a/smoothcrawler_cluster/crawler/workflow.py
+++ b/smoothcrawler_cluster/crawler/workflow.py
@@ -46,12 +46,7 @@ class BaseWorkflow(metaclass=ABCMeta):
         could only use `<BaseWorkflow object>.run(*args, **kwargs)` to run it.
     """
 
-    def __init__(
-        self,
-        name: CrawlerName,
-        path: Type[MetaDataPath],
-        metadata_opts_callback: MetaDataOpt,
-    ):
+    def __init__(self, name: CrawlerName, path: Type[MetaDataPath], metadata_opts_callback: MetaDataOpt):
         """
 
         Args:

--- a/smoothcrawler_cluster/crawler/workflow.py
+++ b/smoothcrawler_cluster/crawler/workflow.py
@@ -61,7 +61,7 @@ class BaseWorkflow(metaclass=ABCMeta):
             metadata_opts_callback (MetaDataOpt): The data object *MetaDataOpt* which provides multiple callback
                 functions about getting and setting meta-data.
         """
-        self._crawler_name = name
+        self._crawler_name_data = name
         self._path = path
         # get_metadata (Callable): The callback function about getting meta-data as object.
         self._get_metadata = metadata_opts_callback.get_callback
@@ -424,8 +424,8 @@ class PrimaryBackupRunnerWorkflow(BaseRoleWorkflow):
             state.total_backup = state.total_backup - 1
             state.current_crawler.remove(dead_crawler_name)
             state.current_runner.remove(dead_crawler_name)
-            state.current_runner.append(str(self._crawler_name))
-            state.current_backup.remove(str(self._crawler_name))
+            state.current_runner.append(str(self._crawler_name_data))
+            state.current_backup.remove(str(self._crawler_name_data))
             state.fail_crawler.append(dead_crawler_name)
             state.fail_runner.append(dead_crawler_name)
             state.standby_id = str(int(state.standby_id) + 1)
@@ -498,7 +498,7 @@ class SecondaryBackupRunnerWorkflow(BaseRoleWorkflow):
         """
         while True:
             group_state = self._get_metadata(path=self._path.group_state, as_obj=GroupState)
-            if str(self._crawler_name.id) == group_state.standby_id:
+            if str(self._crawler_name_data.id) == group_state.standby_id:
                 # Start to do wait_and_standby
                 return True
             time.sleep(timer.time_interval.check_standby_id)

--- a/test/integration_test/crawler/_spec.py
+++ b/test/integration_test/crawler/_spec.py
@@ -3,11 +3,29 @@ from typing import List
 
 from kazoo.client import KazooClient
 
+from smoothcrawler_cluster.crawler import ZookeeperCrawler
+from smoothcrawler_cluster.model._data import CrawlerName
+
 from ..._config import Zookeeper_Hosts
 from ..._values import _Total_Crawler_Value
 from ..._verify import Verify, VerifyMetaData
 from .._test_utils._instance_value import _ZKNodePathUtils
 from .._test_utils._zk_testsuite import ZK
+
+
+def generate_crawler_name(zk_crawler: ZookeeperCrawler = None) -> CrawlerName:
+    name = CrawlerName()
+    if zk_crawler:
+        name.group = zk_crawler.group
+        name.base_name = zk_crawler.name.split(zk_crawler._index_sep)[0]
+        name.index_separation = zk_crawler._index_sep
+        name.id = zk_crawler.name.split(zk_crawler._index_sep)[-1]
+    else:
+        name.group = "pytest"
+        name.base_name = "sc-crawler"
+        name.index_separation = "_"
+        name.id = "1"
+    return name
 
 
 class MultiCrawlerTestSuite(ZK):

--- a/test/integration_test/crawler/_spec.py
+++ b/test/integration_test/crawler/_spec.py
@@ -4,7 +4,7 @@ from typing import List
 from kazoo.client import KazooClient
 
 from smoothcrawler_cluster.crawler import ZookeeperCrawler
-from smoothcrawler_cluster.model._data import CrawlerName
+from smoothcrawler_cluster.model._data import CrawlerName, MetaDataOpt
 
 from ..._config import Zookeeper_Hosts
 from ..._values import _Total_Crawler_Value
@@ -26,6 +26,14 @@ def generate_crawler_name(zk_crawler: ZookeeperCrawler = None) -> CrawlerName:
         name.index_separation = "_"
         name.id = "1"
     return name
+
+
+def generate_metadata_opts(zk_crawler: ZookeeperCrawler = None) -> MetaDataOpt:
+    metadata_opts = MetaDataOpt()
+    metadata_opts.exist_callback = zk_crawler._exist_metadata
+    metadata_opts.get_callback = zk_crawler._get_metadata
+    metadata_opts.set_callback = zk_crawler._set_metadata
+    return metadata_opts
 
 
 class MultiCrawlerTestSuite(ZK):

--- a/test/integration_test/crawler/dispatcher.py
+++ b/test/integration_test/crawler/dispatcher.py
@@ -21,6 +21,7 @@ from ..._config import Zookeeper_Hosts
 from ..._values import _Backup_Crawler_Value, _Runner_Crawler_Value
 from .._test_utils._instance_value import _TestValue
 from .._test_utils._zk_testsuite import ZK, ZKNode
+from ._spec import generate_crawler_name
 
 _Testing_Value: _TestValue = _TestValue()
 
@@ -44,9 +45,7 @@ class TestWorkflowDispatcher(ZK):
         )
 
         return WorkflowDispatcher(
-            crawler_name=zk_crawler.name,
-            group=_Testing_Value.group,
-            index_sep=zk_crawler._index_sep,
+            name=generate_crawler_name(zk_crawler),
             path=zk_crawler._zk_path,
             get_metadata_callback=zk_crawler._get_metadata,
             set_metadata_callback=zk_crawler._set_metadata,

--- a/test/integration_test/crawler/dispatcher.py
+++ b/test/integration_test/crawler/dispatcher.py
@@ -48,7 +48,7 @@ class TestWorkflowDispatcher(ZK):
             name=generate_crawler_name(zk_crawler),
             path=zk_crawler._zk_path,
             metadata_opts_callback=generate_metadata_opts(zk_crawler),
-            opt_metadata_with_lock=DistributedLock(lock=_mock_callable),
+            lock=DistributedLock(lock=_mock_callable),
             crawler_process_callback=_mock_callable,
         )
 

--- a/test/integration_test/crawler/dispatcher.py
+++ b/test/integration_test/crawler/dispatcher.py
@@ -21,7 +21,7 @@ from ..._config import Zookeeper_Hosts
 from ..._values import _Backup_Crawler_Value, _Runner_Crawler_Value
 from .._test_utils._instance_value import _TestValue
 from .._test_utils._zk_testsuite import ZK, ZKNode
-from ._spec import generate_crawler_name
+from ._spec import generate_crawler_name, generate_metadata_opts
 
 _Testing_Value: _TestValue = _TestValue()
 
@@ -47,8 +47,7 @@ class TestWorkflowDispatcher(ZK):
         return WorkflowDispatcher(
             name=generate_crawler_name(zk_crawler),
             path=zk_crawler._zk_path,
-            get_metadata_callback=zk_crawler._get_metadata,
-            set_metadata_callback=zk_crawler._set_metadata,
+            metadata_opts_callback=generate_metadata_opts(zk_crawler),
             opt_metadata_with_lock=DistributedLock(lock=_mock_callable),
             crawler_process_callback=_mock_callable,
         )

--- a/test/integration_test/crawler/workflow.py
+++ b/test/integration_test/crawler/workflow.py
@@ -30,7 +30,7 @@ from ..._values import (
 from ..._verify import VerifyMetaData
 from .._test_utils._instance_value import _TestValue, _ZKNodePathUtils
 from .._test_utils._multirunner import run_2_diff_workers, run_multi_diff_workers
-from ._spec import MultiCrawlerTestSuite, generate_crawler_name
+from ._spec import MultiCrawlerTestSuite, generate_crawler_name, generate_metadata_opts
 
 _Manager = mp.Manager()
 _Testing_Value: _TestValue = _TestValue()
@@ -59,8 +59,7 @@ def _get_base_workflow_arguments(zk_crawler: ZookeeperCrawler) -> dict:
     return {
         "name": generate_crawler_name(zk_crawler),
         "path": zk_crawler._zk_path,
-        "get_metadata": zk_crawler._get_metadata,
-        "set_metadata": zk_crawler._set_metadata,
+        "metadata_opts_callback": generate_metadata_opts(zk_crawler),
     }
 
 

--- a/test/integration_test/crawler/workflow.py
+++ b/test/integration_test/crawler/workflow.py
@@ -70,7 +70,7 @@ def _get_role_workflow_arguments(zk_crawler: ZookeeperCrawler, crawling_callback
         "identifier": zk_crawler._state_identifier,
     }
     workflow_args = {
-        "opt_metadata_with_lock": DistributedLock(lock=zk_crawler._zookeeper_client.restrict, **restrict_args),
+        "lock": DistributedLock(lock=zk_crawler._zookeeper_client.restrict, **restrict_args),
         "crawler_process_callback": (crawling_callback or _mock_crawler_processing_func),
     }
     workflow_args.update(_get_base_workflow_arguments(zk_crawler))

--- a/test/integration_test/crawler/workflow.py
+++ b/test/integration_test/crawler/workflow.py
@@ -30,7 +30,7 @@ from ..._values import (
 from ..._verify import VerifyMetaData
 from .._test_utils._instance_value import _TestValue, _ZKNodePathUtils
 from .._test_utils._multirunner import run_2_diff_workers, run_multi_diff_workers
-from ._spec import MultiCrawlerTestSuite
+from ._spec import MultiCrawlerTestSuite, generate_crawler_name
 
 _Manager = mp.Manager()
 _Testing_Value: _TestValue = _TestValue()
@@ -57,8 +57,7 @@ def _mock_crawler_processing_func(*args, **kwargs) -> str:
 
 def _get_base_workflow_arguments(zk_crawler: ZookeeperCrawler) -> dict:
     return {
-        "crawler_name": zk_crawler.name,
-        "index_sep": zk_crawler._index_sep,
+        "name": generate_crawler_name(zk_crawler),
         "path": zk_crawler._zk_path,
         "get_metadata": zk_crawler._get_metadata,
         "set_metadata": zk_crawler._set_metadata,
@@ -117,8 +116,8 @@ class TestRunnerWorkflow(MultiCrawlerTestSuite):
                 initial=False,
                 zk_hosts=Zookeeper_Hosts,
             )
-            zk_crawler.register_node_state()
-            zk_crawler.register_task()
+            zk_crawler.register.node_state()
+            zk_crawler.register.task()
 
             workflow_args = _get_role_workflow_arguments(zk_crawler)
             workflow = RunnerWorkflow(**workflow_args)
@@ -202,8 +201,8 @@ class TestRunnerWorkflow(MultiCrawlerTestSuite):
                 initial=False,
                 zk_hosts=Zookeeper_Hosts,
             )
-            zk_crawler.register_node_state()
-            zk_crawler.register_task()
+            zk_crawler.register.node_state()
+            zk_crawler.register.task()
 
             workflow_args = _get_role_workflow_arguments(zk_crawler)
             workflow = RunnerWorkflow(**workflow_args)
@@ -290,8 +289,8 @@ class TestRunnerWorkflow(MultiCrawlerTestSuite):
                 initial=False,
                 zk_hosts=Zookeeper_Hosts,
             )
-            zk_crawler.register_node_state()
-            zk_crawler.register_task()
+            zk_crawler.register.node_state()
+            zk_crawler.register.task()
 
             workflow_args = _get_role_workflow_arguments(zk_crawler, crawling_callback=_mock_crawling_processing)
             workflow = RunnerWorkflow(**workflow_args)
@@ -526,8 +525,8 @@ class TestHeartbeatUpdatingWorkflow(MultiCrawlerTestSuite):
             initial=False,
             zk_hosts=Zookeeper_Hosts,
         )
-        zk_crawler.register_task()
-        zk_crawler.register_heartbeat()
+        zk_crawler.register.task()
+        zk_crawler.register.heartbeat()
 
         workflow_args = _get_base_workflow_arguments(zk_crawler)
         workflow = HeartbeatUpdatingWorkflow(**workflow_args)
@@ -579,8 +578,8 @@ class TestHeartbeatUpdatingWorkflow(MultiCrawlerTestSuite):
             initial=False,
             zk_hosts=Zookeeper_Hosts,
         )
-        zk_crawler.register_task()
-        zk_crawler.register_heartbeat()
+        zk_crawler.register.task()
+        zk_crawler.register.heartbeat()
 
         workflow_args = _get_base_workflow_arguments(zk_crawler)
         workflow = HeartbeatUpdatingWorkflow(**workflow_args)

--- a/test/integration_test/register.py
+++ b/test/integration_test/register.py
@@ -17,6 +17,7 @@ from .._values import (
 from .._verify import VerifyMetaData
 from ._test_utils._instance_value import _TestValue, _ZKNodePathUtils
 from ._test_utils._zk_testsuite import ZK, ZKNode, ZKTestSpec
+from .crawler._spec import generate_crawler_name, generate_metadata_opts
 
 _Manager = mp.Manager()
 _Testing_Value: _TestValue = _TestValue()
@@ -37,14 +38,10 @@ class TestZookeeperCrawlerSingleInstance(ZKTestSpec):
             runner=_Runner_Crawler_Value, backup=_Backup_Crawler_Value, initial=False, zk_hosts=Zookeeper_Hosts
         )
         return Register(
-            crawler_name=zk_crawler.name,
-            crawler_group=zk_crawler.group,
-            index_sep=zk_crawler._index_sep,
+            name=generate_crawler_name(zk_crawler),
             path=zk_crawler._zk_path,
-            get_metadata=zk_crawler._get_metadata,
-            set_metadata=zk_crawler._set_metadata,
-            exist_metadata=zk_crawler._exist_metadata,
-            opt_metadata_with_lock=zk_crawler.distributed_lock_adapter,
+            metadata_opts_callback=generate_metadata_opts(zk_crawler),
+            lock=zk_crawler.distributed_lock_adapter,
         )
 
     @ZK.reset_testing_env(path=[ZKNode.GROUP_STATE])

--- a/test/unit_test/crawler/crawlers.py
+++ b/test/unit_test/crawler/crawlers.py
@@ -22,12 +22,10 @@ _Testing_Value: _TestValue = _TestValue()
 
 def _get_workflow_arguments() -> dict:
     workflow_args = {
-        "crawler_name": "test_name",
-        "index_sep": "test_index_sep",
+        "name": Mock(),
         "path": Mock(),
-        "get_metadata": Mock(),
-        "set_metadata": Mock(),
-        "opt_metadata_with_lock": Mock(),
+        "metadata_opts_callback": Mock(),
+        "lock": Mock(),
         "crawler_process_callback": Mock(),
     }
     return workflow_args


### PR DESCRIPTION
### _Target_

* Refactor to use data objects **CrawlerName** and **MetaDataOpt** to let arguments passing to be more simple and clear.


### _Modify Code Scope_

* Source Code
    * module _crawler.workflow_
    * module _crawler.dispatcher_
    * module _crawler.crawlers_
    * module _register_

* Testing Code
    * Unit Test
        * testing module _crawler.workflow_
        * testing module _crawler.dispatcher_
        * testing module _register_

    * Integration Test
        * testing module _crawler.workflow_
        * testing module _crawler.crawlers_


### _Effecting Scope_

* The way to pass arguments of bellow modules:
    * module _crawler.workflow_
    * module _crawler.dispatcher_
    * module _register_

    The passing would be more simple and clear because it use less arguments but with more flexible in usage of these modules.


### _Description_

* Modify to use inner data object to replace some arguments:
    * **CrawlerName**  ->  Replace _crawler_name_ or _name_, _crawler_group_ or _group_, _index_sep_
    * **MetaDataOpt**  ->  Replace _exist_metadata_, _get_metadata_, _set_metadata_

* Rename argument to be more clear.
    * _opt_metadata_with_lock_  ->  Turn to be _lock_

* Refactor the test about the usage code of these arguments.
