### PR TITLE
🔧⚙️🔩 [Breaking Change] (config) Remove the if-condition of workflow running.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -104,7 +104,6 @@ jobs:
 
   all-test_codecov:
 #    name: Organize and generate the testing report and upload it to Codecov
-    if: ${{ github.event_name == 'push' }}
     needs: [run_unit-test, run_integration-test]
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/organize_and_generate_test_cov_reports.yaml@v4
     with:


### PR DESCRIPTION
### _Target_

* Remove the if-condition of workflow running so that CI still could upload test coverage report to **_CodeCov_**.


### _Modify Code Scope_

* Configuration
    * settings in _.github/workflows_


### _Effecting Scope_

* The automation behavior of CI.


### _Description_

It has some external force would trigger CI and it may lead to it cannot record the test coverage report like bellow:

<img width="1334" alt="Screen Shot 2023-03-01 at 9 57 39 AM" src="https://user-images.githubusercontent.com/42397554/222025071-51862b29-2a02-4263-bb01-3efbca1e42ab.png">

So remove the if-condition to let CI would upload all test coverage reports every times.
